### PR TITLE
Rename base to webui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ownCloud User Giudes
+# ownCloud Web User Interface
 
 ## Building the Docs
 
-The ownCloud User Guides are not built independently. Instead, it is built together with the [main documentation](https://github.com/owncloud/docs/). However, you can build a local copy of the ownCloud Server documentation to preview changes you are making.
+The ownCloud Web User Interface Guides are not built independently. Instead, it is built together with the [main documentation](https://github.com/owncloud/docs/). However, you can build a local copy of the ownCloud Server documentation to preview changes you are making.
 
 Whenever a Pull Request of this repo gets merged, it automatically triggers a full docs build.
 
@@ -36,7 +36,7 @@ yarn antora-local
 
 ## Previewing the Generated Docs
 
-Assuming that there are no build errors, the next thing to do is to view the result in your browser. In case you have already installed a web server to access local pages, you need to configure a virtual host (or similar) which points to the directory `public/`, located in the root directory of this repository. This directory contains the generated documentation. Alternatively, use the simple web server `serve` bundled with the current package.json, just execute the following command to serve the documentation at [http://localhost:8080/user/](http://localhost:8080/user/):
+Assuming that there are no build errors, the next thing to do is to view the result in your browser. In case you have already installed a web server to access local pages, you need to configure a virtual host (or similar) which points to the directory `public/`, located in the root directory of this repository. This directory contains the generated documentation. Alternatively, use the simple web server `serve` bundled with the current package.json, just execute the following command to serve the documentation at [http://localhost:8080/webui/](http://localhost:8080/webui/):
 
 ```
 yarn serve
@@ -48,8 +48,8 @@ See the the [following section](https://github.com/owncloud/docs#target-branch-a
 
 ## Branching Workflow
 
-Please refer to the [Branching Workflow for ownCloud Server](https://github.com/owncloud/docs-userguide/blob/master/docs/the-branching-workflow.md) or more information.
+Please refer to the [Branching Workflow for ownCloud Server](https://github.com/owncloud/docs-webui/blob/master/docs/the-branching-workflow.md) or more information.
 
 ## Create a New Version Branch for ownCloud Server
 
-Please refer to [Create a New Version Branch for ownCloud Server](https://github.com/owncloud/docs-userguide/blob/master/docs/new-version-branch.md) for more information.
+Please refer to [Create a New Version Branch for ownCloud Server](https://github.com/owncloud/docs-webui/blob/master/docs/new-version-branch.md) for more information.

--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
-name: user
-title: ownCloud User Guides
+name: webui
+title: ownCloud Web User Interface
 version: next
 start_page: ROOT:index.adoc
 nav:

--- a/bin/find-orphaned-adoc-files
+++ b/bin/find-orphaned-adoc-files
@@ -6,7 +6,7 @@
 #
 # Note that filenames MUST NOT contain blanks
 
-AVAILABLE_MANUALS=( admin user developer ROOT )
+AVAILABLE_MANUALS=( classic_web_ui new_web_ui ROOT )
 # dependend of root or not, the manual name gets a postfix added, name see below
 ROOT_NAME="ROOT"
 # all main nav files from the modules have the name nav.adoc

--- a/bin/find-orphaned-attachment-files
+++ b/bin/find-orphaned-attachment-files
@@ -7,7 +7,7 @@
 #
 # Note that filenames MUST NOT contain blanks
 
-AVAILABLE_MANUALS=( admin user developer ROOT )
+AVAILABLE_MANUALS=( classic_web_ui new_web_ui ROOT )
 ROOT_NAME="ROOT"
 BASE_DIR=""
 MANUAL_POSTFIX="_manual"

--- a/bin/find-orphaned-example-files
+++ b/bin/find-orphaned-example-files
@@ -7,7 +7,7 @@
 #
 # Note that filenames MUST NOT contain blanks
 
-AVAILABLE_MANUALS=( admin user developer ROOT )
+AVAILABLE_MANUALS=( classic_web_ui new_web_ui ROOT )
 ROOT_NAME="ROOT"
 BASE_DIR=""
 MANUAL_POSTFIX="_manual"

--- a/bin/find-orphaned-image-files
+++ b/bin/find-orphaned-image-files
@@ -7,7 +7,7 @@
 #
 # Note that filenames MUST NOT contain blanks
 
-AVAILABLE_MANUALS=( admin user developer ROOT )
+AVAILABLE_MANUALS=( classic_web_ui new_web_ui ROOT )
 ROOT_NAME="ROOT"
 BASE_DIR=""
 MANUAL_POSTFIX="_manual"

--- a/docs/new-version-branch.md
+++ b/docs/new-version-branch.md
@@ -1,3 +1,3 @@
-# Create a New Version Branch for the User Guides
+# Create a New Version Branch for the Web User Interface Guides
 
 **NOTE** For the time being, there is no versioning planned.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,8 +1,8 @@
-= Introduction to ownCloud User Guides
+= Introduction to the ownCloud Web User Interface Guides
 
-Welcome to the ownCloud user guide documentation. There are two user guides available. Both guides cover the access of the ownCloud instance via a browser. 
+Welcome to the ownCloud Web User Interface guides. There are two web user interface guides available. Both guides cover the access of the ownCloud instance via a browser. 
 
-* The first guide, xref:classic_web_ui:index.adoc[User Manual for Server] is for the classic server version and can only be used with the server.
+* The first guide, xref:classic_web_ui:index.adoc[Classic Server UI] is for the classic server version and can only be used with the server.
 
 * The second guide, xref:new_web_ui:index.adoc[New Web UI] is either for the classic server if installed by the admin or is the default user interface when using oCIS.
 +

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,4 @@
-.ownCloud User Guides
+.ownCloud Web User Interface
 * xref:index.adoc[Introduction]
 include::classic_web_ui:partial$nav.adoc[]
 include::new_web_ui:partial$nav.adoc[]

--- a/modules/classic_web_ui/partials/nav.adoc
+++ b/modules/classic_web_ui/partials/nav.adoc
@@ -1,5 +1,5 @@
 // note that the module reference post xref is now a mandatory element
-* User Manual for Server
+* Classic Server UI
 ** xref:classic_web_ui:index.adoc[Introduction]
 ** xref:classic_web_ui:files/webgui/overview.adoc[The WebUI]
 *** xref:classic_web_ui:webinterface.adoc[Web Interface]

--- a/site.yml
+++ b/site.yml
@@ -1,7 +1,7 @@
 site:
   title: ownCloud User Guides
   url: https://doc.owncloud.com
-  start_page: user::index.adoc
+  start_page: webui::index.adoc
 
 content:
   sources:
@@ -32,7 +32,7 @@ asciidoc:
     idseparator: '-'
     experimental: ''
     # the page-component-build-list is used in docs-ui
-    page-component-build-list: 'docs, server, ocis, user, desktop, ios-app, android'
+    page-component-build-list: 'docs, server, ocis, user, webui, desktop, ios-app, android'
 #   common
     docs-base-url: 'https://doc.owncloud.com'
     oc-contact-url: 'https://owncloud.com/contact/'
@@ -63,9 +63,9 @@ asciidoc:
     std-port-memcache: '11211'
     std-port-mysql: '3306'
     std-port-redis: '6379'
-#   user
-    latest-user-version: 'next'
-    previous-user-version: 'next'
+#   webui
+    latest-webui-version: 'next'
+    previous-webui-version: 'next'
   extensions:
     - ./lib/extensions/tabs.js
     - ./lib/extensions/remote-include-processor.js


### PR DESCRIPTION
Because the guides are about the webui, a renaming was necessary