### PR TITLE
Adding more page aliases for the Classic UI

### DIFF
--- a/modules/classic_ui/pages/apps/activity.adoc
+++ b/modules/classic_ui/pages/apps/activity.adoc
@@ -1,6 +1,8 @@
 = The Activity App
 :toc: right
-:page-aliases: next@server:user_manual:apps/activity.adoc
+:page-aliases: next@server:user_manual:apps/activity.adoc, \
+{latest-server-version}@server:user_manual:apps/activity.adoc, \
+{previous-server-version}@server:user_manual:apps/activity.adoc
 
 :description: The ownCloud Activity app gathers all your file or folder related actions in one place for you to review and can notify you about them via email as well. 
 

--- a/modules/classic_ui/pages/apps/calendar.adoc
+++ b/modules/classic_ui/pages/apps/calendar.adoc
@@ -1,5 +1,7 @@
 = Using the Calendar App
-:page-aliases: next@server:user_manual:apps/calendar.adoc
+:page-aliases: next@server:user_manual:apps/calendar.adoc, \
+{latest-server-version}@server:user_manual:apps/calendar.adoc, \
+{previous-server-version}@server:user_manual:apps/calendar.adoc
 
 :description: The Calendar app is not enabled by default in ownCloud and needs to be enabled separately. You can download it via {oc-marketplace-url}/apps/market[the market app].
 

--- a/modules/classic_ui/pages/apps/contacts.adoc
+++ b/modules/classic_ui/pages/apps/contacts.adoc
@@ -1,5 +1,7 @@
 = Using the Contacts App
-:page-aliases: next@server:user_manual:apps/contacts.adoc
+:page-aliases: next@server:user_manual:apps/contacts.adoc, \
+{latest-server-version}@server:user_manual:apps/contacts.adoc, \
+{previous-server-version}@server:user_manual:apps/contacts.adoc
 
 :description: The Contacts app is not enabled by default in ownCloud and needs to be enabled separately. You can download it via {oc-marketplace-url}/apps/market[the market app].
 

--- a/modules/classic_ui/pages/apps/index.adoc
+++ b/modules/classic_ui/pages/apps/index.adoc
@@ -1,5 +1,7 @@
 :section-title: Apps
 :section-preamble-ender: on some of the core apps available with ownCloud 
-:page-aliases: next@server:user_manual:apps/index.adoc
+:page-aliases: next@server:user_manual:apps/index.adoc, \
+{latest-server-version}@server:user_manual:apps/index.adoc, \
+{previous-server-version}@server:user_manual:apps/index.adoc
 
 include::partial$section_page.adoc[]

--- a/modules/classic_ui/pages/apps/market.adoc
+++ b/modules/classic_ui/pages/apps/market.adoc
@@ -1,6 +1,8 @@
 = The Market App
 :keywords: ownCloud Marketplace, ownCloud Market, apps
-:page-aliases: next@server:user_manual:apps/market.adoc
+:page-aliases: next@server:user_manual:apps/market.adoc, \
+{latest-server-version}@server:user_manual:apps/market.adoc, \
+{previous-server-version}@server:user_manual:apps/market.adoc
 
 :description: Here you will find out all you need to know about working with ownCloud's Market app.
 

--- a/modules/classic_ui/pages/apps/media_viewer_app.adoc
+++ b/modules/classic_ui/pages/apps/media_viewer_app.adoc
@@ -4,7 +4,9 @@
 :ogg-url: https://xiph.org/vorbis/
 :mp4-url: https://en.wikipedia.org/wiki/MPEG-4_Part_14
 :media-viewer-app-url: {oc-marketplace-url}/apps/files_mediaviewer
-:page-aliases: next@server:user_manual:apps/media_viewer_app.adoc
+:page-aliases: next@server:user_manual:apps/media_viewer_app.adoc, \
+{latest-server-version}@server:user_manual:apps/media_viewer_app.adoc, \
+{previous-server-version}@server:user_manual:apps/media_viewer_app.adoc
 
 :description: The {media-viewer-app-url}[Media Viewer app] is a lightweight viewer for pictures and videos which integrates with the files app, and is released under the GPLv2.
 

--- a/modules/classic_ui/pages/external_storage/external_storage.adoc
+++ b/modules/classic_ui/pages/external_storage/external_storage.adoc
@@ -1,5 +1,7 @@
 = Configuring External Storage
-:page-aliases: next@server:user_manual:external_storage/external_storage.adoc
+:page-aliases: next@server:user_manual:external_storage/external_storage.adoc, \
+{latest-server-version}@server:user_manual:external_storage/external_storage.adoc, \
+{previous-server-version}@server:user_manual:external_storage/external_storage.adoc
 
 :description: The External Storage application allows you to mount external storage services, such as Google Drive, Dropbox, Amazon S3, SMB/CIFS fileservers, and FTP servers in ownCloud. Your ownCloud server administrator controls which of these are available to you.
 

--- a/modules/classic_ui/pages/external_storage/sharepoint_connecting.adoc
+++ b/modules/classic_ui/pages/external_storage/sharepoint_connecting.adoc
@@ -1,6 +1,8 @@
 = Connecting to SharePoint (Enterprise only)
 :toc: right
-:page-aliases: next@server:user_manual:external_storage/sharepoint_connecting.adoc
+:page-aliases: next@server:user_manual:external_storage/sharepoint_connecting.adoc, \
+{latest-server-version}@server:user_manual:external_storage/sharepoint_connecting.adoc, \
+{previous-server-version}@server:user_manual:external_storage/sharepoint_connecting.adoc
 
 :description: Native SharePoint support has been added to ownCloud Enterprise Subscription as a secondary storage location for SharePoint 2007, 2010 and 2013. To the user, these appear as normal ownCloud mounts, with bi-directional updates in any ownCloud client: desktop, mobile, or Web.
 

--- a/modules/classic_ui/pages/files/access_webdav.adoc
+++ b/modules/classic_ui/pages/files/access_webdav.adoc
@@ -9,7 +9,9 @@
 :office-opens-blank-url: https://docs.microsoft.com/en-us/office/troubleshoot/powerpoint/office-opens-blank-from-sharepoint
 :support-1-url: https://support.microsoft.com/kb/2123563
 :support-2-url: https://support.microsoft.com/kb/2668751
-:page-aliases: next@server:user_manual:files/access_webdav.adoc
+:page-aliases: next@server:user_manual:files/access_webdav.adoc, \
+{latest-server-version}@server:user_manual:files/access_webdav.adoc, \
+{previous-server-version}@server:user_manual:files/access_webdav.adoc
 
 :description: ownCloud fully supports the WebDAV protocol, and you can connect and synchronize with your ownCloud files over WebDAV. In this chapter you will learn how to connect Linux, Mac OS X, Windows and mobile devices to your ownCloud server via WebDAV.
 

--- a/modules/classic_ui/pages/files/deleted_file_management.adoc
+++ b/modules/classic_ui/pages/files/deleted_file_management.adoc
@@ -1,6 +1,8 @@
 = Managing Deleted Files
 :toc: right
-:page-aliases: next@server:user_manual:files/deleted_file_management.adoc
+:page-aliases: next@server:user_manual:files/deleted_file_management.adoc, \
+{latest-server-version}@server:user_manual:files/deleted_file_management.adoc, \
+{previous-server-version}@server:user_manual:files/deleted_file_management.adoc
 
 :description: When you delete a file in ownCloud, it is not immediately deleted permanently. Instead, it is moved into the trash bin. It is not permanently deleted until you manually delete it, or when the Deleted Files app deletes it to make room for new files.
 

--- a/modules/classic_ui/pages/files/desktop_mobile_sync.adoc
+++ b/modules/classic_ui/pages/files/desktop_mobile_sync.adoc
@@ -1,5 +1,7 @@
 = Desktop and Mobile Synchronization
-:page-aliases: next@server:user_manual:files/descktop_mobile_sync.adoc
+:page-aliases: next@server:user_manual:files/desktop_mobile_sync.adoc, \
+{latest-server-version}@server:user_manual:files/desktop_mobile_sync.adoc, \
+{previous-server-version}@server:user_manual:files/desktop_mobile_sync.adoc
 
 :description: Syncronizing files with your desktop computer is most easiest with the Descktop Synchronisation Client. While it is no mandatory, it eases keeping files in sync a lot.
 

--- a/modules/classic_ui/pages/files/encrypting_files.adoc
+++ b/modules/classic_ui/pages/files/encrypting_files.adoc
@@ -1,6 +1,8 @@
 = Encrypting Your ownCloud Files
 :toc: right
-:page-aliases: next@server:user_manual:files/encrypting_files.adoc
+:page-aliases: next@server:user_manual:files/encrypting_files.adoc, \
+{latest-server-version}@server:user_manual:files/encrypting_files.adoc, \
+{previous-server-version}@server:user_manual:files/encrypting_files.adoc
 
 :description: ownCloud includes an Encryption app, and when it is enabled by your ownCloud administrator, all of your ownCloud data files are automatically encrypted.
 

--- a/modules/classic_ui/pages/files/federated_cloud_sharing.adoc
+++ b/modules/classic_ui/pages/files/federated_cloud_sharing.adoc
@@ -1,6 +1,8 @@
 = Using Federation Shares
 :toc: right
-:page-aliases: next@server:user_manual:files/federated_cloud_sharing.adoc
+:page-aliases: next@server:user_manual:files/federated_cloud_sharing.adoc, \
+{latest-server-version}@server:user_manual:files/federated_cloud_sharing.adoc, \
+{previous-server-version}@server:user_manual:files/federated_cloud_sharing.adoc
 
 :description: Federation Sharing allows you to mount file shares from remote ownCloud
 servers, in effect creating your own cloud of ownClouds.

--- a/modules/classic_ui/pages/files/files_lifecycle.adoc
+++ b/modules/classic_ui/pages/files/files_lifecycle.adoc
@@ -1,6 +1,8 @@
 = File Lifecycle Management
 :toc: right
-:page-aliases: next@server:user_manual:files/files_lifecycle.adoc
+:page-aliases: next@server:user_manual:files/files_lifecycle.adoc, \
+{latest-server-version}@server:user_manual:files/files_lifecycle.adoc, \
+{previous-server-version}@server:user_manual:files/files_lifecycle.adoc
 
 :description: With File Lifecycle Management, ownCloud provides a toolset for administrators to automatically move user files into a dedicated archive a certain time after they were uploaded. 
 

--- a/modules/classic_ui/pages/files/index.adoc
+++ b/modules/classic_ui/pages/files/index.adoc
@@ -1,4 +1,6 @@
 = Files
-:page-aliases: next@server:user_manual:files/index.adoc
+:page-aliases: next@server:user_manual:files/index.adoc, \
+{latest-server-version}@server:user_manual:files/index.adoc, \
+{previous-server-version}@server:user_manual:files/index.adoc
 
 This section covers how to work with and user files when using ownCloud.

--- a/modules/classic_ui/pages/files/large_file_upload.adoc
+++ b/modules/classic_ui/pages/files/large_file_upload.adoc
@@ -1,5 +1,7 @@
 = Large File Uploads
-:page-aliases: next@server:user_manual:files/large_file_upload.adoc
+:page-aliases: next@server:user_manual:files/large_file_upload.adoc, \
+{latest-server-version}@server:user_manual:files/large_file_upload.adoc, \
+{previous-server-version}@server:user_manual:files/large_file_upload.adoc
 
 :description: When uploading files through the web client, ownCloud is limited by the server configuration. We recommend that your ownCloud admin updates the server environment to sizes appropriate for users.
 

--- a/modules/classic_ui/pages/files/manual_file_locking.adoc
+++ b/modules/classic_ui/pages/files/manual_file_locking.adoc
@@ -1,6 +1,8 @@
 = Manual File Locking
 :toc: right
-:page-aliases: next@server:user_manual:files/manual_file_locking.adoc
+:page-aliases: next@server:user_manual:files/manual_file_locking.adoc, \
+{latest-server-version}@server:user_manual:files/manual_file_locking.adoc, \
+{previous-server-version}@server:user_manual:files/manual_file_locking.adoc
 
 :description: Manual file locking allows users, if enabled by the ownCloud administrator, to lock files in shared areas while working on them in order to prevent concurrent changes from other users (check-in/check-out).
 

--- a/modules/classic_ui/pages/files/public_link_shares.adoc
+++ b/modules/classic_ui/pages/files/public_link_shares.adoc
@@ -1,5 +1,7 @@
 = Public Link Shares
-:page-aliases: next@server:user_manual:files/public_link_shares.adoc
+:page-aliases: next@server:user_manual:files/public_link_shares.adoc, \
+{latest-server-version}@server:user_manual:files/public_link_shares.adoc, \
+{previous-server-version}@server:user_manual:files/public_link_shares.adoc
 
 :description: With ownCloud X (10.0), the ability to create multiple public links per file or folder was introduced.
 This offers a lot of flexibility for creating different 

--- a/modules/classic_ui/pages/files/version_control.adoc
+++ b/modules/classic_ui/pages/files/version_control.adoc
@@ -1,7 +1,9 @@
 = Version Control
 :tab-type-text: versions
 :tab-type-link: versions
-:page-aliases: next@server:user_manual:files/version_control.adoc
+:page-aliases: next@server:user_manual:files/version_control.adoc, \
+{latest-server-version}@server:user_manual:files/version_control.adoc, \
+{previous-server-version}@server:user_manual:files/version_control.adoc
 
 :description: ownCloud supports a simple version control system for files. Versioning creates backups of files which are accessible via the Versions tab on the Details sidebar.
 

--- a/modules/classic_ui/pages/files/webgui/activity.adoc
+++ b/modules/classic_ui/pages/files/webgui/activity.adoc
@@ -2,7 +2,9 @@
 :toc: right
 :tab-type-text: sharing
 :tab-type-link: share
-:page-aliases: next@server:user_manual:files/webgui/activity.adoc
+:page-aliases: next@server:user_manual:files/webgui/activity.adoc, \
+{latest-server-version}@server:user_manual:files/webgui/activity.adoc, \
+{previous-server-version}@server:user_manual:files/webgui/activity.adoc
 
 :description: Clicking the Activity tab in the Details view in the web browser shows all activities for a file. Activities can include when a file was created, renamed, and deleted.
 

--- a/modules/classic_ui/pages/files/webgui/comments.adoc
+++ b/modules/classic_ui/pages/files/webgui/comments.adoc
@@ -2,7 +2,9 @@
 :toc: right
 :tab-type-text: comments
 :tab-type-link: comments
-:page-aliases: next@server:user_manual:files/webgui/comments.adoc
+:page-aliases: next@server:user_manual:files/webgui/comments.adoc, \
+{latest-server-version}@server:user_manual:files/webgui/comments.adoc, \
+{previous-server-version}@server:user_manual:files/webgui/comments.adoc
 
 :description: In ownCloud, you can add one or more comments on both files and folders. This section describes how to add, edit, and delete comments.
 

--- a/modules/classic_ui/pages/files/webgui/custom_groups.adoc
+++ b/modules/classic_ui/pages/files/webgui/custom_groups.adoc
@@ -1,6 +1,8 @@
 = Custom Groups
 :toc: right
-:page-aliases: next@server:user_manual:files/webgui/custom_groups.adoc
+:page-aliases: next@server:user_manual:files/webgui/custom_groups.adoc, \
+{latest-server-version}@server:user_manual:files/webgui/custom_groups.adoc, \
+{previous-server-version}@server:user_manual:files/webgui/custom_groups.adoc
 
 :description: You can create your own groups on-the-fly, through a feature called "Custom Groups". Here’s how to use it.
 

--- a/modules/classic_ui/pages/files/webgui/details.adoc
+++ b/modules/classic_ui/pages/files/webgui/details.adoc
@@ -2,7 +2,9 @@
 :toc: right
 :tab-type-text: sharing
 :tab-type-link: share
-:page-aliases: next@server:user_manual:files/webgui/details.adoc
+:page-aliases: next@server:user_manual:files/webgui/details.adoc, \
+{latest-server-version}@server:user_manual:files/webgui/details.adoc, \
+{previous-server-version}@server:user_manual:files/webgui/details.adoc
 
 :description: The Details view shows all information for a file, split up into four sections:
 

--- a/modules/classic_ui/pages/files/webgui/navigating.adoc
+++ b/modules/classic_ui/pages/files/webgui/navigating.adoc
@@ -2,7 +2,9 @@
 :toc: right
 :toclevels: 1
 :moz-browser-compatibility-guide-url: https://developer.mozilla.org/en-US/docs/Web/Media/Formats#Browser_compatibility
-:page-aliases: next@server:user_manual:files/webgui/navigating.adoc
+:page-aliases: next@server:user_manual:files/webgui/navigating.adoc, \
+{latest-server-version}@server:user_manual:files/webgui/navigating.adoc, \
+{previous-server-version}@server:user_manual:files/webgui/navigating.adoc
 
 :description: Navigating through folders in ownCloud is as simple as clicking on a folder to open it and using the back button on your browser to move to a previous level. This section walks you through how to navigate the ownCloud UI.
 

--- a/modules/classic_ui/pages/files/webgui/overview.adoc
+++ b/modules/classic_ui/pages/files/webgui/overview.adoc
@@ -1,7 +1,9 @@
 = WebUI Overview
 :toc: right
 :toclevels: 1
-:page-aliases: next@server:user_manual:files/webgui/overview.adoc
+:page-aliases: next@server:user_manual:files/webgui/overview.adoc, \
+{latest-server-version}@server:user_manual:files/webgui/overview.adoc, \
+{previous-server-version}@server:user_manual:files/webgui/overview.adoc
 
 :description: You can access your files with the ownCloud Web interface, as well as: create, preview, edit, delete, share, and re-share files.
 

--- a/modules/classic_ui/pages/files/webgui/quota.adoc
+++ b/modules/classic_ui/pages/files/webgui/quota.adoc
@@ -1,6 +1,8 @@
 = Storage Quotas
 :toc: right
-:page-aliases: next@server:user_manual:files/webgui/quota.adoc
+:page-aliases: next@server:user_manual:files/webgui/quota.adoc, \
+{latest-server-version}@server:user_manual:files/webgui/quota.adoc, \
+{previous-server-version}@server:user_manual:files/webgui/quota.adoc
 
 :description: Your ownCloud admin has the option to set a storage quota on users. Look
 at the top of your Personal page to see what your quota is, and how much

--- a/modules/classic_ui/pages/files/webgui/search.adoc
+++ b/modules/classic_ui/pages/files/webgui/search.adoc
@@ -1,6 +1,8 @@
 = Search & Full Text Search
 :toc: right
-:page-aliases: next@server:user_manual:files/webgui/search.adoc
+:page-aliases: next@server:user_manual:files/webgui/search.adoc, \
+{latest-server-version}@server:user_manual:files/webgui/search.adoc, \
+{previous-server-version}@server:user_manual:files/webgui/search.adoc
 
 :description: ownCloud comes with a regular search function allowing you to find files by their file name or parts of it. Click on the the magnifier icon in the upper right-hand corner of the web interface. In addition, the Full Text Search app can be enabled. 
 

--- a/modules/classic_ui/pages/files/webgui/sharing.adoc
+++ b/modules/classic_ui/pages/files/webgui/sharing.adoc
@@ -2,7 +2,9 @@
 :toc: right
 :tab-type-text: sharing
 :tab-type-link: share
-:page-aliases: next@server:user_manual:files/webgui/sharing.adoc
+:page-aliases: next@server:user_manual:files/webgui/sharing.adoc, \
+{latest-server-version}@server:user_manual:files/webgui/sharing.adoc, \
+{previous-server-version}@server:user_manual:files/webgui/sharing.adoc
 
 :description: Clicking the share icon on any file or folder opens the Details view on
 the right, where the Share tab has focus.

--- a/modules/classic_ui/pages/files/webgui/tagging.adoc
+++ b/modules/classic_ui/pages/files/webgui/tagging.adoc
@@ -1,6 +1,8 @@
 = Tagging Files
 :toc: right
-:page-aliases: next@server:user_manual:files/webgui/tagging.adoc
+:page-aliases: next@server:user_manual:files/webgui/tagging.adoc, \
+{latest-server-version}@server:user_manual:files/webgui/tagging.adoc, \
+{previous-server-version}@server:user_manual:files/webgui/tagging.adoc
 
 :description: ownCloud provides via the webinterface the ability to assign one or more tags to files and folders.
 

--- a/modules/classic_ui/pages/found_a_mistake.adoc
+++ b/modules/classic_ui/pages/found_a_mistake.adoc
@@ -1,6 +1,8 @@
 = Have You Found a Mistake In The Documentation?
 :new-issue-url: https://github.com/owncloud/docs/issues/new
-:page-aliases: next@server:user_manual:found_a_mistake.adoc
+:page-aliases: next@server:user_manual:found_a_mistake.adoc, \
+{latest-server-version}@server:user_manual:found_a_mistake.adoc, \
+{previous-server-version}@server:user_manual:found_a_mistake.adoc
 
 :description: If you have found a mistake in the documentation, no matter how large or small, please let us know by {new-issue-url}[creating a new issue in the docs repository].
 

--- a/modules/classic_ui/pages/index.adoc
+++ b/modules/classic_ui/pages/index.adoc
@@ -1,5 +1,7 @@
 = Introduction
-:page-aliases: next@server:user_manual:index.adoc
+:page-aliases: next@server:user_manual:index.adoc, \
+{latest-server-version}@server:user_manual:index.adoc, \
+{previous-server-version}@server:user_manual:index.adoc
 
 :description: ownCloud is an open source file sync and share software for everyone from individuals operating the free ownCloud Server edition, to large enterprises and service providers operating the ownCloud Enterprise Subscription.
 

--- a/modules/classic_ui/pages/integration/index.adoc
+++ b/modules/classic_ui/pages/integration/index.adoc
@@ -1,5 +1,7 @@
 = Integration
-:page-aliases: next@server:user_manual:integration/index.adoc
+:page-aliases: next@server:user_manual:integration/index.adoc, \
+{latest-server-version}@server:user_manual:integration/index.adoc, \
+{previous-server-version}@server:user_manual:integration/index.adoc
 
 This section is dedicated to integrating ownCloud with other products, for now only Microsoft Teams, but more to come.
 

--- a/modules/classic_ui/pages/integration/ms-teams.adoc
+++ b/modules/classic_ui/pages/integration/ms-teams.adoc
@@ -1,6 +1,8 @@
 = Integrate ownCloud into Microsoft Teams
 :toc: right
-:page-aliases: next@server:user_manual:integration/ms-teams.adoc
+:page-aliases: next@server:user_manual:integration/ms-teams.adoc, \
+{latest-server-version}@server:user_manual:integration/ms-teams.adoc, \
+{previous-server-version}@server:user_manual:integration/ms-teams.adoc
 
 :description: You can access your ownCloud via Microsoft Teams if your administrator has created an app available in your organization's app catalog. It is possible that the admin already has enabled the app for the users, in this case you do not need to search for it in your organization's app catalog as it is already pinned.
 

--- a/modules/classic_ui/pages/online_collaboration.adoc
+++ b/modules/classic_ui/pages/online_collaboration.adoc
@@ -2,7 +2,9 @@
 :collabora-online-url: https://www.collaboraoffice.com/collabora-online/
 :libreoffice-url: https://www.libreoffice.org/
 :secure-view-label: Secure View (with watermarks)
-:page-aliases: next@server:user_manual:online_collaboration.adoc
+:page-aliases: next@server:user_manual:online_collaboration.adoc, \
+{latest-server-version}@server:user_manual:online_collaboration.adoc, \
+{previous-server-version}@server:user_manual:online_collaboration.adoc
 
 :description: {collabora-online-url}[Collabora Online] is a powerful {libreoffice-url}[LibreOffice]-based online office that supports all major document, spreadsheet and presentation file formats, and is integrable with ownCloud.
 

--- a/modules/classic_ui/pages/personal_settings/general.adoc
+++ b/modules/classic_ui/pages/personal_settings/general.adoc
@@ -1,7 +1,9 @@
 = General Settings
 :toc: right
 :toclevels: 2
-:page-aliases: next@server:user_manual:personal_settings/general.adoc
+:page-aliases: next@server:user_manual:personal_settings/general.adoc, \
+{latest-server-version}@server:user_manual:personal_settings/general.adoc, \
+{previous-server-version}@server:user_manual:personal_settings/general.adoc
 
 :description: In general settings, some of the features you will see include the following:
 

--- a/modules/classic_ui/pages/personal_settings/index.adoc
+++ b/modules/classic_ui/pages/personal_settings/index.adoc
@@ -1,5 +1,7 @@
 = Personal Settings
-:page-aliases: next@server:user_manual:personal_settings/index.adoc
+:page-aliases: next@server:user_manual:personal_settings/index.adoc, \
+{latest-server-version}@server:user_manual:personal_settings/index.adoc, \
+{previous-server-version}@server:user_manual:personal_settings/index.adoc
 
 :description: As a user, you can manage your personal settings. To access them: Click on your username in the top, right-hand corner of the WebUI of your ownCloud instance.
 

--- a/modules/classic_ui/pages/personal_settings/security.adoc
+++ b/modules/classic_ui/pages/personal_settings/security.adoc
@@ -6,7 +6,9 @@
 :gps-google-auth-url: https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en&gl=US
 :ios-2fas-url: https://apps.apple.com/app/2fa-authenticator-2fas/id1217793794
 :gps-2fas-url: https://play.google.com/store/apps/details?id=com.twofasapp&hl=en&gl=US
-:page-aliases: next@server:user_manual:personal_settings/security.adoc
+:page-aliases: next@server:user_manual:personal_settings/security.adoc, \
+{latest-server-version}@server:user_manual:personal_settings/security.adoc, \
+{previous-server-version}@server:user_manual:personal_settings/security.adoc
 
 == Introduction
 

--- a/modules/classic_ui/pages/personal_settings/sharing.adoc
+++ b/modules/classic_ui/pages/personal_settings/sharing.adoc
@@ -1,5 +1,7 @@
 = Sharing
-:page-aliases: next@server:user_manual:personal_settings/sharing.adoc
+:page-aliases: next@server:user_manual:personal_settings/sharing.adoc, \
+{latest-server-version}@server:user_manual:personal_settings/sharing.adoc, \
+{previous-server-version}@server:user_manual:personal_settings/sharing.adoc
 
 == Introduction
 

--- a/modules/classic_ui/pages/personal_settings/storage.adoc
+++ b/modules/classic_ui/pages/personal_settings/storage.adoc
@@ -1,5 +1,7 @@
 = External Storage
-:page-aliases: next@server:user_manual:personal_settings/storage.adoc
+:page-aliases: next@server:user_manual:personal_settings/storage.adoc, \
+{latest-server-version}@server:user_manual:personal_settings/storage.adoc, \
+{previous-server-version}@server:user_manual:personal_settings/storage.adoc
 
 :description: If your ownCloud administrator has enabled *External Storage* for users, you will be able to add one or multiple external storages depending on the allowed storage types.
 

--- a/modules/classic_ui/pages/pim/index.adoc
+++ b/modules/classic_ui/pages/pim/index.adoc
@@ -1,5 +1,7 @@
 = Contacts & Calendar
-:page-aliases: next@server:user_manual:pim/index.adoc
+:page-aliases: next@server:user_manual:pim/index.adoc, \
+{latest-server-version}@server:user_manual:pim/index.adoc, \
+{previous-server-version}@server:user_manual:pim/index.adoc
 
 :description: The Contacts, Calendar, and Mail apps can be installed from the ownCloud Marketplace in the  menu:Market[Productivity] category and can be installed by clicking btn:[Install] on their respective entries but are not with official support.
 

--- a/modules/classic_ui/pages/pim/sync_ios.adoc
+++ b/modules/classic_ui/pages/pim/sync_ios.adoc
@@ -1,6 +1,8 @@
 = iOS - Synchronize iPhone/iPad
 :toc: right
-:page-aliases: next@server:user_manual:pim/sync_ios.adoc
+:page-aliases: next@server:user_manual:pim/sync_ios.adoc, \
+{latest-server-version}@server:user_manual:pim/sync_ios.adoc, \
+{previous-server-version}@server:user_manual:pim/sync_ios.adoc
 
 == Calendar
 

--- a/modules/classic_ui/pages/pim/sync_kde.adoc
+++ b/modules/classic_ui/pages/pim/sync_kde.adoc
@@ -1,5 +1,7 @@
 = Synchronizing with KDE SC
-:page-aliases: next@server:user_manual:pim/sync_kde.adoc
+:page-aliases: next@server:user_manual:pim/sync_kde.adoc, \
+{latest-server-version}@server:user_manual:pim/sync_kde.adoc, \
+{previous-server-version}@server:user_manual:pim/sync_kde.adoc
 
 image:kdes1.png[image]
 

--- a/modules/classic_ui/pages/pim/sync_osx.adoc
+++ b/modules/classic_ui/pages/pim/sync_osx.adoc
@@ -1,5 +1,7 @@
 = Synchronizing with OS X
-:page-aliases: next@server:user_manual:pim/sync_osx.adoc
+:page-aliases: next@server:user_manual:pim/sync_osx.adoc, \
+{latest-server-version}@server:user_manual:pim/sync_osx.adoc, \
+{previous-server-version}@server:user_manual:pim/sync_osx.adoc
 
 To use ownCloud with iCal you will need to use the following URL:
 

--- a/modules/classic_ui/pages/pim/sync_thunderbird.adoc
+++ b/modules/classic_ui/pages/pim/sync_thunderbird.adoc
@@ -1,5 +1,8 @@
 = Thunderbird - Synchronize Addressbook
-:page-aliases: next@server:user_manual:pim/sync_thunderbird.adoc
+:page-aliases: next@server:user_manual:pim/sync_thunderbird.adoc, \
+{latest-server-version}@server:user_manual:pim/sync_thunderbird.adoc, \
+{previous-server-version}@server:user_manual:pim/sync_thunderbird.adoc
+
 
 As someone who is new to ownCloud, new to SoGo Connector, and new to
 Thunderbird Addressbook, here is what you need in excruciating pithy

--- a/modules/classic_ui/pages/session_management.adoc
+++ b/modules/classic_ui/pages/session_management.adoc
@@ -1,6 +1,8 @@
 = Session Management
 :toc: right
-:page-aliases: next@server:user_manual:session_management.adoc
+:page-aliases: next@server:user_manual:session_management.adoc, \
+{latest-server-version}@server:user_manual:session_management.adoc, \
+{previous-server-version}@server:user_manual:session_management.adoc
 
 :description: The personal settings page allows you to have an overview of the connected browsers and clients. It is accessed by selecting the
 

--- a/modules/classic_ui/pages/troubleshooting.adoc
+++ b/modules/classic_ui/pages/troubleshooting.adoc
@@ -1,6 +1,8 @@
 = Troubleshooting
 :toc: right
-:page-aliases: next@server:user_manual:troubleshooting.adoc
+:page-aliases: next@server:user_manual:troubleshooting.adoc, \
+{latest-server-version}@server:user_manual:troubleshooting.adoc, \
+{previous-server-version}@server:user_manual:troubleshooting.adoc
 
 :description: Listed here are the most common errors you may encounter while attempting to upload files, along with what they mean and possible workarounds.
 

--- a/modules/classic_ui/pages/webinterface.adoc
+++ b/modules/classic_ui/pages/webinterface.adoc
@@ -1,5 +1,7 @@
 = The Web Interface
-:page-aliases: next@server:user_manual:webinterface.adoc
+:page-aliases: next@server:user_manual:webinterface.adoc, \
+{latest-server-version}@server:user_manual:webinterface.adoc, \
+{previous-server-version}@server:user_manual:webinterface.adoc
 
 :description: You can connect to your ownCloud server using any Web browser; just point it to your ownCloud server and enter your username and password. Supported Web browsers are:
 

--- a/site.yml
+++ b/site.yml
@@ -46,8 +46,8 @@ asciidoc:
 #   server
     # note that the version attributes just need to be present and have next as key
     # as they are just here for the test build
-    latest-server-version: 'next'
-    previous-server-version: 'next'
+    latest-server-version: '10.9'
+    previous-server-version: '10.8'
     latest-server-download-version: 'next'
     current-server-version: 'next'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'


### PR DESCRIPTION
After an intense discussion with @jnweiger, we agreed to have not only page aliases (redirects) for the `next` version, but also for the `latest` and `previous` server version. Using attributes makes this a one time change.

This is because we have migrated the user manual from the server into its own repository and do not use branches in the new repository anymore but want to keep the former access fully available.