### PR TITLE
Adding ownCloud Web to docs for publishing

### DIFF
--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -1,3 +1,3 @@
 * xref:index.adoc[Introduction]
 include::classic_ui:partial$nav.adoc[]
-// include::owncloud_web:partial$nav.adoc[]
+include::owncloud_web:partial$nav.adoc[]


### PR DESCRIPTION
This PR adds ownCloud Web to the ownCloud documentation.
Has been tested locally and works fine.

Keeping this as WIP up to the point we get the final ok