### PR TITLE
small changes

### DIFF
--- a/modules/classic_ui/pages/files/webgui/custom_groups.adoc
+++ b/modules/classic_ui/pages/files/webgui/custom_groups.adoc
@@ -13,63 +13,40 @@
 == Creating Custom Groups
 
 Assuming that your ownCloud administrator’s already
-xref:{latest-server-version}@server:admin_manual:configuration/user/user_configuration.adoc#enabling-custom-groups[enabled custom groups];
- under the admin menu, in the top right-hand corner,
-click btn:[Settings] (1). Then, in the main menu on the settings page,
-in "**Personal**" section, click the option: btn:[Customgroups] (2).
-This will take you to the "**Custom Groups**" admin page.
+xref:{latest-server-version}@server:admin_manual:configuration/user/user_configuration.adoc#enabling-custom-groups[enabled custom groups]; under the admin menu, in the top right-hand corner, click btn:[Settings] (1). Then, in the main menu on the settings page, in the btn:[Personal] section, click the option: btn:[Customgroups] (2). This will take you to the btn:[Custom Groups] admin page.
 
 image:custom-groups/owncloud-create-custom-group-annotated.png[The Custom Groups administration panel]
 
-To create a new custom group, in the text field at the top where you see the placeholder
-text: "**Group name**", add the group name and click btn:[Create group].
-After a moment or two, you’ll see the new custom group appear in the groups list.
+To create a new custom group, in the text field at the top where you see the placeholder text: btn:[Group name], add the group name and click btn:[Create group]. After a moment or two, you’ll see the new custom group appear in the groups list.
 
 [NOTE]
 ====
 Please be aware of two things:
 
-. Custom groups are visible *only* to members of the group, but *not* to anyone outside the group; and
-. ownCloud administrators can see and modify all custom groups of an instance (default setting, can be modified via config.php)
+. Custom groups are visible *only* to members of the group, but *not* to anyone outside the group
+. By default, ownCloud administrators can see and modify all custom groups of an instance. This setting can be modified via xref:{latest-server-version}@server:admin_manual:configuration/user/user_management.adoc#overriding-default-behavior[config.php or an occ command].
 ====
 
 == Managing Group Members
 
 image:custom-groups/custom-group-manage-group-members.png[Manage members in a custom group]
 
-To add or remove users in a custom group, click your role (1), which
-will likely be "**Member**" (at least at first), and you’ll see a
-panel appear on the right-hand side listing the group’s users and their
-roles. In the "**Add user to this group field**" at the top of the
-panel (2), start typing the name of the user that you want to add.
+To add or remove users in a custom group, click your role (1), which will likely be btn:[Member] (at least at first), and you’ll see a panel appear on the right-hand side listing the group’s users and their roles. In the btn:[Add user to this group field] at the top of the panel (2), start typing the name of the user that you want to add.
 
-After a moment or two, you’ll see a list of users that match what you’ve
-typed appear (if there are any) in a popup list. Click the one that you
-want, and they’ll be added to the group. Finally, you’ll see a
-confirmation at the top of the page (3), indicating that the user’s been
-added to the custom group.
+After a moment or two, you’ll see a list of users that match what you’ve typed appear (if there are any) in a popup list. Click the one that you want, and they’ll be added to the group. Finally, you’ll see a confirmation at the top of the page (3), indicating that the user’s been added to the custom group.
 
-NOTE: Members can only use a group for sharing, whereas group owners can manage a group’s members,
-change a group’s name, change members’ roles, and delete groups. You can add as many group owners as you like.
+NOTE: Members can only use a group for sharing, whereas group owners can manage a group’s members, change a group’s name, change members’ roles, and delete groups. You can add as many group owners as you like.
 
 == Sharing with the Group
 
 image:custom-groups/owncloud-share-to-custom-group.png[Sharing files and folders with custom groups]
 
-To share a file or folder with your custom group, open the sharing panel
-(1). Then, in the "**User and Groups**" field (2), type part of the
-name of the custom group and wait a moment or two.
+To share a file or folder with your custom group, open the sharing panel (1). Then, in the btn:[User and Groups] field (2), type part of the name of the custom group and wait a moment or two.
 
-The name of the group should be displayed in a popup list, which you can
-see in the screenshot above. Click on it, and the file or folder will
-then be shared with your custom group with all permissions initially set.
+The name of the group should be displayed in a popup list, which you can see in the screenshot above. Click on it, and the file or folder will then be shared with your custom group with all permissions initially set.
 
 == Changing Group Names
 
-If you want to change the name of the custom group, mouseover the
-group’s name in the custom groups list, where you will see a pencil
-appear to the right of the existing name. Click it, and a text field
-will appear, pre-populated with the existing name. Change the name and
-click enter, and the name will be changed.
+If you want to change the name of the custom group, mouseover the group’s name in the custom groups list, where you will see a pencil appear to the right of the existing name. Click it, and a text field will appear, pre-populated with the existing name. Change the name and click enter, and the name will be changed.
 
 image:custom-groups/rename-custom-group.png[Rename a custom group]

--- a/modules/classic_ui/pages/files/webgui/custom_groups.adoc
+++ b/modules/classic_ui/pages/files/webgui/custom_groups.adoc
@@ -30,7 +30,7 @@ After a moment or two, you’ll see the new custom group appear in the groups li
 Please be aware of two things:
 
 . Custom groups are visible *only* to members of the group, but *not* to anyone outside the group; and
-. ownCloud administrators can see and modify all custom groups of an instance.
+. ownCloud administrators can see and modify all custom groups of an instance (default setting, can be modified via config.php)
 ====
 
 == Managing Group Members
@@ -49,8 +49,8 @@ want, and they’ll be added to the group. Finally, you’ll see a
 confirmation at the top of the page (3), indicating that the user’s been
 added to the custom group.
 
-NOTE: Members can only use a group for sharing, whereas group admins can manage a group’s members,
-change a group’s name, change members’ roles, and delete groups.
+NOTE: Members can only use a group for sharing, whereas group owners can manage a group’s members,
+change a group’s name, change members’ roles, and delete groups. You can add as many group owners as you like.
 
 == Sharing with the Group
 


### PR DESCRIPTION
clarified new setting to assure admin users can't see groups
add to the note that there can be as many group owners as you like
change name from group admin to group owner as thats what the UI has