### PR TITLE
Fixing the user search documentation (ownCloud classic)

### DIFF
--- a/modules/classic_ui/pages/files/webgui/search.adoc
+++ b/modules/classic_ui/pages/files/webgui/search.adoc
@@ -4,24 +4,40 @@
 {latest-server-version}@server:user_manual:files/webgui/search.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/search.adoc
 
-:description: ownCloud comes with a regular search function allowing you to find files by their file name or parts of it. Click on the magnifier icon in the upper right-hand corner of the web interface. In addition, the Full Text Search app can be enabled.
+:description: ownCloud comes with a regular search function allowing you to find files by their file name or parts of their names. Click on the magnifier icon in the upper right-hand corner of the web interface. In addition, a Full Text Search app can be enabled by your administrator.
 
 == Introduction
 
-{description} This is something the system administrator needs to take care of. For more information on deploying it, refer to the respective section in the xref:{latest-server-version}@server:admin_manual:configuration/search/index.adoc[Admin Manual].
+{description} Refer to the xref:{latest-server-version}@server:admin_manual:configuration/general_topics/search.adoc[Full Text Search] app in the ownCloud Admin Manual for more information how to deploy it.
 
 == Regular Search
 
-The regular search function in the ownCloud web interface offers a simple search for elements of file names. This also works when you only enter "pain" but meant to look for Spain. However, you also get results for pain or painful. If you start at the top level "All files", you will also see results in subfolders. If you change into a directory, the search starts in this folder, displays the results, then continues to search in all other folders.
+The regular search function provided as base functionality in the ownCloud web interface offers a simple search for *file names* only. Note that no file content will be part of any search result. 
 
-A click on one of the results takes you either to the location of the file, if you are not already in that folder, or the item is opened.
+=== Rules for Regular Search
 
-The search is not case-sensitive, so capital letters are treated the same as lower case characters. You can type Spain or spain and will get the same results. When you start typing, the search also starts.
+* Search is not case-sensitive, capital letters are treated the same as lower case characters. You can type Spain or spain and will get the same results.
+* When you start typing, search also starts.
+* The search term is taken as it is and not interpreted to refine search results.
+* When entering the pattern to search for, you get results for *any filenames* that contains that pattern.
+* When starting at the top level of your files, which is "All files", you will also see results in subfolders.
+* When changing into a directory, search starts in this folder, displays the results, and continues to search in subsequent folders.
+* A click on one of the results takes you either to the location of the file, if you are not already in that folder, or the item is opened.
 
-== Full Text Search App
+== Full Text Search
 
-Things get tricky when you don't remember what the file you're looking for was called and guess work doesn't help. A key word search within text documents is only possible if the Full Text Search app is installed. Contact your admin if you need it and it's not installed. With this app enabled, you can search within files of the most common formats. Like with the regular search, you can enter only the first part of a string and it matches all occurrences of words starting with the search string.
+The Full Text Search app enables you to search not only for file names but also for content inside files. The most common file formats are supported. 
+ 
+=== Rules for Full Text Search
 
-If you are looking for all terms containing a specific string like in the above example "pain", wildcards can be used, e.g. an asterisk: *ain gives you results like braine, pain, Spain and painful. Using a question mark instead of the asterisk limits the preceding characters to exactly one. In this example, only pain and painful would show up if you entered the search string "?ain".
+* Like with the regular search, you can enter only the first part of a string and it matches all occurrences of words starting with the search string.
 
+* *OR case:* When using more than one search term _without_ any quotes, separated by a blank, each term is treated with a logical OR, case insensitive. Searching for _Desktop_ _Sync_ will return all results that contain _Desktop_ or _Sync_.
+ 
+* *AND / NOT case:* When using more than one search term _prefixed_ either by a plus (\+) or minus (-) symbol, separated by a blank, each term that is prefixed with a `+` is treated with a logical AND repectively when prefixed with a `-` with a logical NOT case insensitive. Searching for +_Desktop_ +_Sync_ -MSI will return all results that contain _Desktop_ AND _Sync_ but not NOT _MSI_.
+
+* *Exact case:* When using more than one search term _enclosed_ with quotes, separated by a blank, the complete term is the search pattern. Searching for "_Desktop_ _Sync_" will return all results that contain _Desktop Sync_. Note that beside any match, all existing file names are additionally listed as matches.
+
+* *Wildcards:* When looking for all terms containing a specific string like "pain", wildcards can be used. Using an `asterisk` like `*ain` gives you results like braine, pain, Spain and painful. Using a `question mark` like `?ain` limits the preceding characters to exactly one, only pain and painful would show up.
++
 TIP: Using the asterisk within a word will ignore everything that follows after the asterisk. A trailing asterisk is always assumed in the search.

--- a/modules/classic_ui/pages/files/webgui/search.adoc
+++ b/modules/classic_ui/pages/files/webgui/search.adoc
@@ -8,7 +8,7 @@
 
 == Introduction
 
-{description} Refer to the xref:{latest-server-version}@server:admin_manual:configuration/general_topics/search.adoc[Full Text Search] app in the ownCloud Admin Manual for more information how to deploy it.
+{description} Refer to the xref:{latest-server-version}@server:admin_manual:configuration/general_topics/search.adoc[Full Text Search] app in the ownCloud Admin Manual for more information about how to deploy it.
 
 == Regular Search
 
@@ -19,7 +19,7 @@ The regular search function provided as base functionality in the ownCloud web i
 * Search is not case-sensitive, capital letters are treated the same as lower case characters. You can type Spain or spain and will get the same results.
 * When you start typing, search also starts.
 * The search term is taken as it is and not interpreted to refine search results.
-* When entering the pattern to search for, you get results for *any filenames* that contains that pattern.
+* When entering the pattern to search for, you get results for *any filenames* that contain that pattern.
 * When starting at the top level of your files, which is "All files", you will also see results in subfolders.
 * When changing into a directory, search starts in this folder, displays the results, and continues to search in subsequent folders.
 * A click on one of the results takes you either to the location of the file, if you are not already in that folder, or the item is opened.
@@ -34,7 +34,7 @@ The Full Text Search app enables you to search not only for file names but also 
 
 * *OR case:* When using more than one search term _without_ any quotes, separated by a blank, each term is treated with a logical OR, case insensitive. Searching for _Desktop_ _Sync_ will return all results that contain _Desktop_ or _Sync_.
  
-* *AND / NOT case:* When using more than one search term _prefixed_ either by a plus (\+) or minus (-) symbol, separated by a blank, each term that is prefixed with a `+` is treated with a logical AND repectively when prefixed with a `-` with a logical NOT case insensitive. Searching for +_Desktop_ +_Sync_ -MSI will return all results that contain _Desktop_ AND _Sync_ but not NOT _MSI_.
+* *AND / NOT case:* When using more than one search term _prefixed_ either by a plus (\+) or minus (-) symbol, separated by a blank, each term that is prefixed with a `+` is treated with a logical AND, terms that are prefixed with a `-` are treated as a logical NOT. All checks are case insensitive. Searching for +_Desktop_ +_Sync_ -MSI will return all results that contain _Desktop_ AND _Sync_ but not NOT _MSI_.
 
 * *Exact case:* When using more than one search term _enclosed_ with quotes, separated by a blank, the complete term is the search pattern. Searching for "_Desktop_ _Sync_" will return all results that contain _Desktop Sync_. Note that beside any match, all existing file names are additionally listed as matches.
 


### PR DESCRIPTION
Rewrite of the user search documentation

Fixes: https://github.com/owncloud/docs-webui/issues/54 (classic ui - search needs an update)
Fixes: https://github.com/owncloud/search_elastic/issues/286 ([QA] quotes in search string partly misbehave)

For the QA issue, this PR fixes the missing behaviour documentation.

Language Review welcomed

@jnweiger @pmaier1 fyi