### PR TITLE
Update the activity app

### DIFF
--- a/modules/classic_ui/pages/apps/activity.adoc
+++ b/modules/classic_ui/pages/apps/activity.adoc
@@ -21,7 +21,7 @@ To view notifications, click the hamburger menu, in the top left-hand corner of 
 
 image::apps/activity/activity-menu.png[View activity in ownCloud's WebUI.]
 
-By default, you see all activity related to your files and folders. However, by using the left-hand navigation menu, you can filter activity by:
+By default, you see all activity related to your files and folders. However, by using the left-hand navigation menu, you can filter activities by:
 
 * Activities by you
 * Activities by others
@@ -33,7 +33,7 @@ image::apps/activity/comment-activity.png[View comment activity in ownCloud's We
 
 == Configuring the Activity App
 
-To configure your Activity preferences navigate to menu:Settings[Personal > General > Activity]. You can configure notifications for when:
+To configure your Activity preferences, navigate to menu:Settings[Personal > General > Activity]. You can configure notifications for events like:
 
 * Files and folders are created, changed, deleted, restored (from the trash bin), and shared.
 * Files and folders are shared from another server.
@@ -59,5 +59,5 @@ In addition to enabling and disabling email notifications, bulk email notificati
 
 == Time Base
 
-* An admin can define a default date for shares to expire, which you can change if needed. Whenever a date is set for expiring shares (e.g. after 7 days), the share expires at the end of that day. The time base is the time of the ownCloud server, not the time of the client accessing the ownCloud Server.
-* When a client receives an expiry notification for a share, the expiry is effective at the end of the day based on the time of the ownCloud server and not the time of the client accessing ownCloud Server.
+* An admin can define a default date for shares to expire, which you can change if needed. Whenever a date is set for expiring shares (e.g. after 7 days), the share expires at the end of that day. The time base is the time of the ownCloud server, not the time of the client accessing the ownCloud server.
+* When a client receives an expiry notification for a share, the expiry is effective at the end of the day based on the time of the ownCloud server and not the time of the client accessing ownCloud server.

--- a/modules/classic_ui/pages/apps/activity.adoc
+++ b/modules/classic_ui/pages/apps/activity.adoc
@@ -59,5 +59,5 @@ In addition to enabling and disabling email notifications, bulk email notificati
 
 == Time Base
 
-* An admin can define a default date for shares to expire you can overwrite if needed. Whenever a default date is enabled and set for expiring shares (e.g. after 7 days), the time base for default dates is the time of the ownCloud server, not the time of the client accessing ownCloud Server.
-* When a client recieves an expiry notifications for a share, the notification is by the end of the day based on the time of the ownCloud server and not the time of the client accessing ownCloud Server.
+* An admin can define a default date for shares to expire, which you can change if needed. Whenever a date is set for expiring shares (e.g. after 7 days), the share expires at the end of that day. The time base is the time of the ownCloud server, not the time of the client accessing the ownCloud Server.
+* When a client receives an expiry notification for a share, the expiry is effective at the end of the day based on the time of the ownCloud server and not the time of the client accessing ownCloud Server.

--- a/modules/classic_ui/pages/apps/activity.adoc
+++ b/modules/classic_ui/pages/apps/activity.adoc
@@ -12,8 +12,7 @@
 
 [TIP] 
 ====
-The Activity App is shipped and enabled by default. 
-If it is not enabled, contact your ownCloud administrator to have it enabled.
+The Activity App is shipped and enabled by default. If it is not enabled, contact your ownCloud administrator to have it enabled.
 ====
 
 == Viewing Notifications
@@ -22,8 +21,7 @@ To view notifications, click the hamburger menu, in the top left-hand corner of 
 
 image::apps/activity/activity-menu.png[View activity in ownCloud's WebUI.]
 
-By default, you see all activity related to your files and folders.
-However, by using the left-hand navigation menu, you can filter activity by:
+By default, you see all activity related to your files and folders. However, by using the left-hand navigation menu, you can filter activity by:
 
 * Activities by you
 * Activities by others
@@ -35,8 +33,7 @@ image::apps/activity/comment-activity.png[View comment activity in ownCloud's We
 
 == Configuring the Activity App
 
-To configure your Activity preferences navigate to menu:Settings[Personal > General > Activity]. 
-You can configure notifications for when:
+To configure your Activity preferences navigate to menu:Settings[Personal > General > Activity]. You can configure notifications for when:
 
 * Files and folders are created, changed, deleted, restored (from the trash bin), and shared.
 * Files and folders are shared from another server.
@@ -58,5 +55,9 @@ image::apps/activity/activity-settings-limit-to-favorites.png[Limit activity set
 
 === Configuring the Email Notification Interval
 
-In addition to enabling and disabling email notifications, bulk email notifications can be configured to be sent out: _As soon as possible_ (during the next cron execution), _Hourly_, _Daily_, and _Weekly_.
-To do so, pick the interval in the "_Send emails:_" drop-down field at the bottom of the Activity configuration panel.
+In addition to enabling and disabling email notifications, bulk email notifications can be configured to be sent out: _As soon as possible_ (during the next cron execution), _Hourly_, _Daily_, and _Weekly_. To do so, pick the interval in the "_Send emails:_" drop-down field at the bottom of the Activity configuration panel.
+
+== Time Base
+
+* An admin can define a default date for shares to expire you can overwrite if needed. Whenever a default date is enabled and set for expiring shares (e.g. after 7 days), the time base for default dates is the time of the ownCloud server, not the time of the client accessing ownCloud Server.
+* When a client recieves an expiry notifications for a share, the notification is by the end of the day based on the time of the ownCloud server and not the time of the client accessing ownCloud Server.


### PR DESCRIPTION
References: https://github.com/owncloud/docs-server/issues/592 ([QA] describe expectatins about expiry notifications)

Add some info about the time base when it comes to email notifications for expired shares and default expiration dates.

Removing some unneccessary linebreakes.