### PR TITLE
Move and update the description attribute to the correct place

### DIFF
--- a/modules/classic_ui/pages/apps/activity.adoc
+++ b/modules/classic_ui/pages/apps/activity.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:apps/activity.adoc, \
 {latest-server-version}@server:user_manual:apps/activity.adoc, \
 {previous-server-version}@server:user_manual:apps/activity.adoc
-
 :description: The ownCloud Activity app gathers all your file or folder related actions in one place for you to review and can notify you about them via email as well. 
 
 == Introduction

--- a/modules/classic_ui/pages/apps/calendar.adoc
+++ b/modules/classic_ui/pages/apps/calendar.adoc
@@ -2,7 +2,6 @@
 :page-aliases: next@server:user_manual:apps/calendar.adoc, \
 {latest-server-version}@server:user_manual:apps/calendar.adoc, \
 {previous-server-version}@server:user_manual:apps/calendar.adoc
-
 :description: The Calendar app is not enabled by default in ownCloud and needs to be enabled separately. You can download it via {oc-marketplace-url}/apps/market[the market app].
 
 {description}

--- a/modules/classic_ui/pages/apps/contacts.adoc
+++ b/modules/classic_ui/pages/apps/contacts.adoc
@@ -2,7 +2,6 @@
 :page-aliases: next@server:user_manual:apps/contacts.adoc, \
 {latest-server-version}@server:user_manual:apps/contacts.adoc, \
 {previous-server-version}@server:user_manual:apps/contacts.adoc
-
 :description: The Contacts app is not enabled by default in ownCloud and needs to be enabled separately. You can download it via {oc-marketplace-url}/apps/market[the market app].
 
 {description}

--- a/modules/classic_ui/pages/apps/market.adoc
+++ b/modules/classic_ui/pages/apps/market.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:apps/market.adoc, \
 {latest-server-version}@server:user_manual:apps/market.adoc, \
 {previous-server-version}@server:user_manual:apps/market.adoc
-
 :description: Here you will find out all you need to know about working with ownCloud's Market app.
 
 == Log in to the Marketplace From the Market App

--- a/modules/classic_ui/pages/apps/media_viewer_app.adoc
+++ b/modules/classic_ui/pages/apps/media_viewer_app.adoc
@@ -7,7 +7,6 @@
 :page-aliases: next@server:user_manual:apps/media_viewer_app.adoc, \
 {latest-server-version}@server:user_manual:apps/media_viewer_app.adoc, \
 {previous-server-version}@server:user_manual:apps/media_viewer_app.adoc
-
 :description: The {media-viewer-app-url}[Media Viewer app] is a lightweight viewer for pictures and videos which integrates with the files app, and is released under the GPLv2.
 
 == Introduction

--- a/modules/classic_ui/pages/external_storage/external_storage.adoc
+++ b/modules/classic_ui/pages/external_storage/external_storage.adoc
@@ -2,7 +2,6 @@
 :page-aliases: next@server:user_manual:external_storage/external_storage.adoc, \
 {latest-server-version}@server:user_manual:external_storage/external_storage.adoc, \
 {previous-server-version}@server:user_manual:external_storage/external_storage.adoc
-
 :description: The External Storage application allows you to mount external storage services, such as Google Drive, Dropbox, Amazon S3, SMB/CIFS fileservers, and FTP servers in ownCloud. Your ownCloud server administrator controls which of these are available to you.
 
 {description} Please see

--- a/modules/classic_ui/pages/external_storage/sharepoint_connecting.adoc
+++ b/modules/classic_ui/pages/external_storage/sharepoint_connecting.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:external_storage/sharepoint_connecting.adoc, \
 {latest-server-version}@server:user_manual:external_storage/sharepoint_connecting.adoc, \
 {previous-server-version}@server:user_manual:external_storage/sharepoint_connecting.adoc
-
 :description: Native SharePoint support has been added to ownCloud Enterprise Subscription as a secondary storage location for SharePoint 2007, 2010 and 2013. To the user, these appear as normal ownCloud mounts, with bi-directional updates in any ownCloud client: desktop, mobile, or Web.
 
 == Introduction

--- a/modules/classic_ui/pages/files/access_webdav.adoc
+++ b/modules/classic_ui/pages/files/access_webdav.adoc
@@ -12,7 +12,6 @@
 :page-aliases: next@server:user_manual:files/access_webdav.adoc, \
 {latest-server-version}@server:user_manual:files/access_webdav.adoc, \
 {previous-server-version}@server:user_manual:files/access_webdav.adoc
-
 :description: ownCloud fully supports the WebDAV protocol, and you can connect and synchronize with your ownCloud files over WebDAV. In this chapter you will learn how to connect Linux, Mac OS X, Windows and mobile devices to your ownCloud server via WebDAV.
 
 == Introduction

--- a/modules/classic_ui/pages/files/deleted_file_management.adoc
+++ b/modules/classic_ui/pages/files/deleted_file_management.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:files/deleted_file_management.adoc, \
 {latest-server-version}@server:user_manual:files/deleted_file_management.adoc, \
 {previous-server-version}@server:user_manual:files/deleted_file_management.adoc
-
 :description: When you delete a file in ownCloud, it is not immediately deleted permanently. Instead, it is moved into the trash bin. It is not permanently deleted until you manually delete it, or when the Deleted Files app deletes it to make room for new files.
 
 == Introduction

--- a/modules/classic_ui/pages/files/desktop_mobile_sync.adoc
+++ b/modules/classic_ui/pages/files/desktop_mobile_sync.adoc
@@ -2,7 +2,6 @@
 :page-aliases: next@server:user_manual:files/desktop_mobile_sync.adoc, \
 {latest-server-version}@server:user_manual:files/desktop_mobile_sync.adoc, \
 {previous-server-version}@server:user_manual:files/desktop_mobile_sync.adoc
-
 :description: Syncronizing files with your desktop computer is easiest with the Desktop Synchronisation Client. While it is not mandatory, it eases keeping files in sync a lot.
 
 == Introduction

--- a/modules/classic_ui/pages/files/encrypting_files.adoc
+++ b/modules/classic_ui/pages/files/encrypting_files.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:files/encrypting_files.adoc, \
 {latest-server-version}@server:user_manual:files/encrypting_files.adoc, \
 {previous-server-version}@server:user_manual:files/encrypting_files.adoc
-
 :description: ownCloud includes an Encryption app, and when it is enabled by your ownCloud administrator, all of your ownCloud data files are automatically encrypted.
 
 == Introduction

--- a/modules/classic_ui/pages/files/federated_cloud_sharing.adoc
+++ b/modules/classic_ui/pages/files/federated_cloud_sharing.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:files/federated_cloud_sharing.adoc, \
 {latest-server-version}@server:user_manual:files/federated_cloud_sharing.adoc, \
 {previous-server-version}@server:user_manual:files/federated_cloud_sharing.adoc
-
 :description: Federation Sharing allows you to mount file shares from remote ownCloud
 servers, in effect creating your own cloud of ownClouds.
 

--- a/modules/classic_ui/pages/files/files_lifecycle.adoc
+++ b/modules/classic_ui/pages/files/files_lifecycle.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:files/files_lifecycle.adoc, \
 {latest-server-version}@server:user_manual:files/files_lifecycle.adoc, \
 {previous-server-version}@server:user_manual:files/files_lifecycle.adoc
-
 :description: With File Lifecycle Management, ownCloud provides a toolset for administrators to automatically move user files into a dedicated archive a certain time after they were uploaded. 
 
 == Introduction

--- a/modules/classic_ui/pages/files/large_file_upload.adoc
+++ b/modules/classic_ui/pages/files/large_file_upload.adoc
@@ -2,7 +2,6 @@
 :page-aliases: next@server:user_manual:files/large_file_upload.adoc, \
 {latest-server-version}@server:user_manual:files/large_file_upload.adoc, \
 {previous-server-version}@server:user_manual:files/large_file_upload.adoc
-
 :description: When uploading files through the web client, ownCloud is limited by the server configuration. We recommend that your ownCloud admin updates the server environment to sizes appropriate for users.
 
 {description}

--- a/modules/classic_ui/pages/files/manual_file_locking.adoc
+++ b/modules/classic_ui/pages/files/manual_file_locking.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:files/manual_file_locking.adoc, \
 {latest-server-version}@server:user_manual:files/manual_file_locking.adoc, \
 {previous-server-version}@server:user_manual:files/manual_file_locking.adoc
-
 :description: If enabled by the ownCloud administrator, manual file locking allows users to lock files in shared areas while working on them in order to prevent concurrent changes from other users (check-in/check-out).
 
 == Introduction

--- a/modules/classic_ui/pages/files/public_link_shares.adoc
+++ b/modules/classic_ui/pages/files/public_link_shares.adoc
@@ -2,7 +2,6 @@
 :page-aliases: next@server:user_manual:files/public_link_shares.adoc, \
 {latest-server-version}@server:user_manual:files/public_link_shares.adoc, \
 {previous-server-version}@server:user_manual:files/public_link_shares.adoc
-
 :description: With ownCloud X (10.0), the ability to create multiple public links per file or folder was introduced.
 This offers a lot of flexibility for creating different 
 

--- a/modules/classic_ui/pages/files/version_control.adoc
+++ b/modules/classic_ui/pages/files/version_control.adoc
@@ -4,7 +4,6 @@
 :page-aliases: next@server:user_manual:files/version_control.adoc, \
 {latest-server-version}@server:user_manual:files/version_control.adoc, \
 {previous-server-version}@server:user_manual:files/version_control.adoc
-
 :description: ownCloud provides a simple version control system for files. Versioning creates backups of files which are accessible via the Versions tab on the Details sidebar.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/activity.adoc
+++ b/modules/classic_ui/pages/files/webgui/activity.adoc
@@ -5,7 +5,6 @@
 :page-aliases: next@server:user_manual:files/webgui/activity.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/activity.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/activity.adoc
-
 :description: Clicking the Activity tab in the Details view in the web browser shows all activities for a file. Activities can include when a file was created, renamed, and deleted.
 
 {description}

--- a/modules/classic_ui/pages/files/webgui/comments.adoc
+++ b/modules/classic_ui/pages/files/webgui/comments.adoc
@@ -5,7 +5,6 @@
 :page-aliases: next@server:user_manual:files/webgui/comments.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/comments.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/comments.adoc
-
 :description: In ownCloud, you can add one or more comments on both files and folders. This section describes how to add, edit, and delete comments.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/details.adoc
+++ b/modules/classic_ui/pages/files/webgui/details.adoc
@@ -5,7 +5,6 @@
 :page-aliases: next@server:user_manual:files/webgui/details.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/details.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/details.adoc
-
 :description: The Details view shows all information for a file, split up into four sections:
 
 {description}

--- a/modules/classic_ui/pages/files/webgui/navigating.adoc
+++ b/modules/classic_ui/pages/files/webgui/navigating.adoc
@@ -5,7 +5,6 @@
 :page-aliases: next@server:user_manual:files/webgui/navigating.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/navigating.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/navigating.adoc
-
 :description: Navigating through folders in ownCloud is as simple as clicking on a folder to open it and using the back button on your browser to move to a previous level. This section walks you through how to navigate the ownCloud UI.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/overview.adoc
+++ b/modules/classic_ui/pages/files/webgui/overview.adoc
@@ -4,7 +4,6 @@
 :page-aliases: next@server:user_manual:files/webgui/overview.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/overview.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/overview.adoc
-
 :description: You can access your files with the ownCloud Web interface, as well as: create, preview, edit, delete, share, and re-share files.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/quota.adoc
+++ b/modules/classic_ui/pages/files/webgui/quota.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:files/webgui/quota.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/quota.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/quota.adoc
-
 :description: Your ownCloud admin has the option to set a storage quota on users. Look
 at the top of your Personal page to see what your quota is, and how much
 you have used.

--- a/modules/classic_ui/pages/files/webgui/search.adoc
+++ b/modules/classic_ui/pages/files/webgui/search.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:files/webgui/search.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/search.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/search.adoc
-
 :description: ownCloud comes with a regular search function allowing you to find files by their file name or parts of their names. Click on the magnifier icon in the upper right-hand corner of the web interface. In addition, a Full Text Search app can be enabled by your administrator.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/sharing.adoc
+++ b/modules/classic_ui/pages/files/webgui/sharing.adoc
@@ -5,7 +5,6 @@
 :page-aliases: next@server:user_manual:files/webgui/sharing.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/sharing.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/sharing.adoc
-
 :description: Clicking the share icon on any file or folder opens the Details view on the right, where the Share tab has focus.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/tagging.adoc
+++ b/modules/classic_ui/pages/files/webgui/tagging.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:files/webgui/tagging.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/tagging.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/tagging.adoc
-
 :description: ownCloud provides via the webinterface the ability to assign one or more tags to files and folders.
 
 == Introduction

--- a/modules/classic_ui/pages/found_a_mistake.adoc
+++ b/modules/classic_ui/pages/found_a_mistake.adoc
@@ -1,9 +1,9 @@
 = Have You Found a Mistake In The Documentation?
+:description: If you have found a mistake in the documentation, no matter how large or small, please let us know by {new-issue-url}[creating a new issue in the docs repository].
+
 :new-issue-url: https://github.com/owncloud/docs/issues/new
 :page-aliases: next@server:user_manual:found_a_mistake.adoc, \
 {latest-server-version}@server:user_manual:found_a_mistake.adoc, \
 {previous-server-version}@server:user_manual:found_a_mistake.adoc
-
-:description: If you have found a mistake in the documentation, no matter how large or small, please let us know by {new-issue-url}[creating a new issue in the docs repository].
 
 {description}

--- a/modules/classic_ui/pages/index.adoc
+++ b/modules/classic_ui/pages/index.adoc
@@ -1,9 +1,8 @@
 = Introduction
+:description: ownCloud is an open source file sync and share software for everyone from individuals operating the free ownCloud Server edition, to large enterprises and service providers operating the ownCloud Enterprise Subscription.
 :page-aliases: next@server:user_manual:index.adoc, \
 {latest-server-version}@server:user_manual:index.adoc, \
 {previous-server-version}@server:user_manual:index.adoc
-
-:description: ownCloud is an open source file sync and share software for everyone from individuals operating the free ownCloud Server edition, to large enterprises and service providers operating the ownCloud Enterprise Subscription.
 
 *Welcome to ownCloud: your self-hosted file sync and share solution.*
 

--- a/modules/classic_ui/pages/integration/ms-teams.adoc
+++ b/modules/classic_ui/pages/integration/ms-teams.adoc
@@ -3,7 +3,6 @@
 :page-aliases: next@server:user_manual:integration/ms-teams.adoc, \
 {latest-server-version}@server:user_manual:integration/ms-teams.adoc, \
 {previous-server-version}@server:user_manual:integration/ms-teams.adoc
-
 :description: You can access your ownCloud via Microsoft Teams if your administrator has created an app available in your organization's app catalog. It is possible that the admin already has enabled the app for the users, in this case you do not need to search for it in your organization's app catalog as it is already pinned.
 
 == Introduction

--- a/modules/classic_ui/pages/online_collaboration.adoc
+++ b/modules/classic_ui/pages/online_collaboration.adoc
@@ -1,4 +1,7 @@
 = Online Collaboration
+:toc: right
+:description: Collabora Online is a powerful LibreOffice based online office that supports all major document, spreadsheet and presentation file formats, and is integrable with ownCloud.
+
 :collabora-online-url: https://www.collaboraoffice.com/collabora-online/
 :libreoffice-url: https://www.libreoffice.org/
 :secure-view-label: Secure View (with watermarks)
@@ -6,11 +9,9 @@
 {latest-server-version}@server:user_manual:online_collaboration.adoc, \
 {previous-server-version}@server:user_manual:online_collaboration.adoc
 
-:description: {collabora-online-url}[Collabora Online] is a powerful {libreoffice-url}[LibreOffice]-based online office that supports all major document, spreadsheet and presentation file formats, and is integrable with ownCloud.
-
 == Collabora Online
 
-{description}
+{description} See the {collabora-online-url}[Collabora Online] and {libreoffice-url}[LibreOffice] for more details.
 
 === Secure View
 

--- a/modules/classic_ui/pages/personal_settings/custom_groups.adoc
+++ b/modules/classic_ui/pages/personal_settings/custom_groups.adoc
@@ -4,7 +4,6 @@
 next@server:user_manual:files/webgui/custom_groups.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/custom_groups.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/custom_groups.adoc
-
 :description: With custom groups, users are able to define their own groups and manage contributing users themselves.
 
 == Introduction

--- a/modules/classic_ui/pages/personal_settings/general.adoc
+++ b/modules/classic_ui/pages/personal_settings/general.adoc
@@ -4,7 +4,6 @@
 :page-aliases: next@server:user_manual:personal_settings/general.adoc, \
 {latest-server-version}@server:user_manual:personal_settings/general.adoc, \
 {previous-server-version}@server:user_manual:personal_settings/general.adoc
-
 :description: In general settings, some of the features you will see include the following:
 
 == Introduction

--- a/modules/classic_ui/pages/personal_settings/index.adoc
+++ b/modules/classic_ui/pages/personal_settings/index.adoc
@@ -2,7 +2,6 @@
 :page-aliases: next@server:user_manual:personal_settings/index.adoc, \
 {latest-server-version}@server:user_manual:personal_settings/index.adoc, \
 {previous-server-version}@server:user_manual:personal_settings/index.adoc
-
 :description: As a user, you can manage your personal settings. To access them: Click on your username in the top, right-hand corner of the WebUI of your ownCloud instance.
 
 {description} The Personal Settings Menu opens.

--- a/modules/classic_ui/pages/personal_settings/storage.adoc
+++ b/modules/classic_ui/pages/personal_settings/storage.adoc
@@ -2,7 +2,6 @@
 :page-aliases: next@server:user_manual:personal_settings/storage.adoc, \
 {latest-server-version}@server:user_manual:personal_settings/storage.adoc, \
 {previous-server-version}@server:user_manual:personal_settings/storage.adoc
-
 :description: If your ownCloud administrator has enabled *External Storage* for users, you will be able to add one or multiple external storages depending on the allowed storage types.
 
 == Introduction

--- a/modules/classic_ui/pages/pim/index.adoc
+++ b/modules/classic_ui/pages/pim/index.adoc
@@ -2,7 +2,6 @@
 :page-aliases: next@server:user_manual:pim/index.adoc, \
 {latest-server-version}@server:user_manual:pim/index.adoc, \
 {previous-server-version}@server:user_manual:pim/index.adoc
-
 :description: The Contacts, Calendar, and Mail apps can be installed from the ownCloud Marketplace in the  menu:Market[Productivity] category and can be installed by clicking btn:[Install] on their respective entries but are not with official support.
 
 {description}

--- a/modules/classic_ui/pages/session_management.adoc
+++ b/modules/classic_ui/pages/session_management.adoc
@@ -1,13 +1,13 @@
 = Session Management
 :toc: right
-:description: The personal settings page allows you to have an overview of the connected browsers and clients. It is accessed by selecting the
+:description: The personal settings page allows you to have an overview of the connected browsers and clients.
 :page-aliases: next@server:user_manual:session_management.adoc, \
 {latest-server-version}@server:user_manual:session_management.adoc, \
 {previous-server-version}@server:user_manual:session_management.adoc
 
 == Introduction
 
-{description} menu:Settings[Personal > Security].
+{description} It is accessed by selecting the menu:Settings[Personal > Security].
 
 == Sessions
 

--- a/modules/classic_ui/pages/session_management.adoc
+++ b/modules/classic_ui/pages/session_management.adoc
@@ -1,10 +1,9 @@
 = Session Management
 :toc: right
+:description: The personal settings page allows you to have an overview of the connected browsers and clients. It is accessed by selecting the
 :page-aliases: next@server:user_manual:session_management.adoc, \
 {latest-server-version}@server:user_manual:session_management.adoc, \
 {previous-server-version}@server:user_manual:session_management.adoc
-
-:description: The personal settings page allows you to have an overview of the connected browsers and clients. It is accessed by selecting the
 
 == Introduction
 

--- a/modules/classic_ui/pages/troubleshooting.adoc
+++ b/modules/classic_ui/pages/troubleshooting.adoc
@@ -1,10 +1,9 @@
 = Troubleshooting
 :toc: right
+:description: Listed here are the most common errors you may encounter while attempting to upload files, along with what they mean and possible workarounds.
 :page-aliases: next@server:user_manual:troubleshooting.adoc, \
 {latest-server-version}@server:user_manual:troubleshooting.adoc, \
 {previous-server-version}@server:user_manual:troubleshooting.adoc
-
-:description: Listed here are the most common errors you may encounter while attempting to upload files, along with what they mean and possible workarounds.
 
 == Introduction
 

--- a/modules/classic_ui/pages/webinterface.adoc
+++ b/modules/classic_ui/pages/webinterface.adoc
@@ -1,9 +1,8 @@
 = The Web Interface
+:description: You can connect to your ownCloud server using any Web browser; just point it to your ownCloud server and enter your username and password. Supported Web browsers are:
 :page-aliases: next@server:user_manual:webinterface.adoc, \
 {latest-server-version}@server:user_manual:webinterface.adoc, \
 {previous-server-version}@server:user_manual:webinterface.adoc
-
-:description: You can connect to your ownCloud server using any Web browser; just point it to your ownCloud server and enter your username and password. Supported Web browsers are:
 
 == Introduction
 

--- a/modules/owncloud_web/pages/index.adoc
+++ b/modules/owncloud_web/pages/index.adoc
@@ -1,6 +1,5 @@
 = ownCloud Web
 :toc: right
-
 :description: ownCloud web comes with a completely new design that is more user-friendly and intuitive and, of course, optimized for Infinite Scale.
 
 == Introduction

--- a/modules/owncloud_web/pages/requirements.adoc
+++ b/modules/owncloud_web/pages/requirements.adoc
@@ -1,6 +1,5 @@
 = Requirements
 :toc: right
-
 :description: To run ownCloud Web with full satisfaction, some requirements must be met.
 
 == Introduction

--- a/modules/owncloud_web/pages/themed_webui.adoc
+++ b/modules/owncloud_web/pages/themed_webui.adoc
@@ -1,10 +1,11 @@
 = ownCloud Web with Custom Theming
 :toc: right
 :toclevels: 1
+:description: Just like with other clients (Desktop, Android, iOS), themes can be used with ownCloud Web. As an organization or company you may be interested in theming the ownCloud web user interface with your brand and slogan, while playful private individuals may simply enjoy the fun of decorating ownCloud web the way they like.
+
 :example-theme-url: https://github.com/owncloud/web/tree/master/config
 :design-tokens-url: https://owncloud.design/#/Design%20Tokens
 :gh-webui-url: https://github.com/owncloud/web/issues/new
-:description: Just like with other clients (Desktop, Android, iOS), themes can be used with ownCloud Web. As an organization or company you may be interested in theming the ownCloud web user interface with your brand and slogan, while playful private individuals may simply enjoy the fun of decorating ownCloud web the way they like.
 
 == Introduction
 

--- a/modules/owncloud_web/pages/web_for_admins.adoc
+++ b/modules/owncloud_web/pages/web_for_admins.adoc
@@ -1,7 +1,6 @@
 = ownCloud Web for Admins
 :toc: right
 :toc-levels: 1
-
 :description: Logged in to Infinite Scale with privileged rights like an admin user, you can perform administration tasks. These include user and group management and creating spaces.
 
 == Introduction

--- a/modules/owncloud_web/pages/web_for_users.adoc
+++ b/modules/owncloud_web/pages/web_for_users.adoc
@@ -1,7 +1,5 @@
 = ownCloud Web for Users
 :toc: right
-// screenshots still to be added.
-
 :description: These sections describe the web UI from a regular user's perspective without administrator privileges.
 
 == Introduction

--- a/modules/owncloud_web/pages/web_with_oc_server.adoc
+++ b/modules/owncloud_web/pages/web_with_oc_server.adoc
@@ -1,11 +1,12 @@
 = ownCloud Web on ownCloud Server
 :toc: right
+:description: ownCloud web is available for ownCloud Server as an app. To ease the transition from ownCloud Server to Infinite Scale, we recommend deploying the new user interface.
+
 :onlyoffice-owncloud-web-url: https://github.com/ONLYOFFICE/onlyoffice-owncloud-web
-:description: ownCloud web is available for ownCloud Server as an app. To ease the transition from ownCloud Server to Infinite Scale, we recommend deploying the new https://marketplace.owncloud.com/apps/web[Web app].
 
 == Introduction
 
-{description}
+{description} It can be downloaded from the marketplace as https://marketplace.owncloud.com/apps/web[Web app].
 
 ownCloud users will benefit from the following additions and improvements:
 


### PR DESCRIPTION
When using the attribute `:description:` which creates a meta tag in htm for search engines when rendered, you need to use two rules:

* It must be under the section header, not in aprticular order, but without a blank line above
* You must not use any links or attributes like `xref:{url}[text]` - will not get resolved and taken as it is

Found by chance. This PR corrects this for the docs-webui repo.

This will now make search engines print predefined text more likely than before when returning search results.