### PR TITLE
Update public_link_shares.adoc

### DIFF
--- a/modules/classic_ui/pages/files/public_link_shares.adoc
+++ b/modules/classic_ui/pages/files/public_link_shares.adoc
@@ -66,6 +66,12 @@ Finally, click the btn:[Save] button to complete creation of the share. Now that
 | Setting
 | Description
 
+////
+// Not existing yet. Will likely be implemented in owncloud server 10.13.0.
+| Preview
+| When set, a recipient can only preview the document via Collabora Online. Note that previews are only available for office documents and implemented in most recent versions of ownCloud. Compared to secure view, watermarking is not used.
+////
+
 | Download / View
 | Allows recipients to view or download the public link's contents.
 

--- a/modules/classic_ui/pages/files/public_link_shares.adoc
+++ b/modules/classic_ui/pages/files/public_link_shares.adoc
@@ -66,9 +66,6 @@ Finally, click the btn:[Save] button to complete creation of the share. Now that
 | Setting
 | Description
 
-| Preview
-| When set, a recipient can only preview the document via Collabora Online. Note that previews are only available for office documents and implemented in most recent versions of ownCloud. Compared to secure view, watermarking is not used.
-
 | Download / View
 | Allows recipients to view or download the public link's contents.
 


### PR DESCRIPTION
Preview role for public links does not exist yet. Will likely be implemented in 10.13.0. References to it should be removed.