### PR TITLE
Fix classic_ui page aliases (Antora 3 prep)

### DIFF
--- a/modules/classic_ui/pages/apps/activity.adoc
+++ b/modules/classic_ui/pages/apps/activity.adoc
@@ -1,8 +1,11 @@
 = The Activity App
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:apps/activity.adoc, \
 {latest-server-version}@server:user_manual:apps/activity.adoc, \
 {previous-server-version}@server:user_manual:apps/activity.adoc
+endif::[]
 :description: The ownCloud Activity app gathers all your file or folder related actions in one place for you to review and can notify you about them via email as well. 
 
 == Introduction

--- a/modules/classic_ui/pages/apps/calendar.adoc
+++ b/modules/classic_ui/pages/apps/calendar.adoc
@@ -1,7 +1,10 @@
 = Using the Calendar App
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:apps/calendar.adoc, \
 {latest-server-version}@server:user_manual:apps/calendar.adoc, \
 {previous-server-version}@server:user_manual:apps/calendar.adoc
+endif::[]
 :description: The Calendar app is not enabled by default in ownCloud and needs to be enabled separately. You can download it via {oc-marketplace-url}/apps/market[the market app].
 
 {description}

--- a/modules/classic_ui/pages/apps/contacts.adoc
+++ b/modules/classic_ui/pages/apps/contacts.adoc
@@ -1,7 +1,10 @@
 = Using the Contacts App
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:apps/contacts.adoc, \
 {latest-server-version}@server:user_manual:apps/contacts.adoc, \
 {previous-server-version}@server:user_manual:apps/contacts.adoc
+endif::[]
 :description: The Contacts app is not enabled by default in ownCloud and needs to be enabled separately. You can download it via {oc-marketplace-url}/apps/market[the market app].
 
 {description}

--- a/modules/classic_ui/pages/apps/index.adoc
+++ b/modules/classic_ui/pages/apps/index.adoc
@@ -1,7 +1,10 @@
 :section-title: Apps
 :section-preamble-ender: on some of the core apps available with ownCloud 
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:apps/index.adoc, \
 {latest-server-version}@server:user_manual:apps/index.adoc, \
 {previous-server-version}@server:user_manual:apps/index.adoc
+endif::[]
 
 include::partial$section_page.adoc[]

--- a/modules/classic_ui/pages/apps/market.adoc
+++ b/modules/classic_ui/pages/apps/market.adoc
@@ -1,8 +1,11 @@
 = The Market App
 :keywords: ownCloud Marketplace, ownCloud Market, apps
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:apps/market.adoc, \
 {latest-server-version}@server:user_manual:apps/market.adoc, \
 {previous-server-version}@server:user_manual:apps/market.adoc
+endif::[]
 :description: Here you will find out all you need to know about working with ownCloud's Market app.
 
 == Log in to the Marketplace From the Market App

--- a/modules/classic_ui/pages/apps/media_viewer_app.adoc
+++ b/modules/classic_ui/pages/apps/media_viewer_app.adoc
@@ -1,13 +1,17 @@
 = The Media Viewer App
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
+:page-aliases: next@server:user_manual:apps/media_viewer_app.adoc, \
+{latest-server-version}@server:user_manual:apps/media_viewer_app.adoc, \
+{previous-server-version}@server:user_manual:apps/media_viewer_app.adoc
+endif::[]
 :browser-image-support-url: https://en.wikipedia.org/wiki/Comparison_of_web_browsers#Image_format_support
 :webm-url: https://www.webmproject.org/
 :ogg-url: https://xiph.org/vorbis/
 :mp4-url: https://en.wikipedia.org/wiki/MPEG-4_Part_14
 :media-viewer-app-url: {oc-marketplace-url}/apps/files_mediaviewer
-:page-aliases: next@server:user_manual:apps/media_viewer_app.adoc, \
-{latest-server-version}@server:user_manual:apps/media_viewer_app.adoc, \
-{previous-server-version}@server:user_manual:apps/media_viewer_app.adoc
 :description: The {media-viewer-app-url}[Media Viewer app] is a lightweight viewer for pictures and videos which integrates with the files app, and is released under the GPLv2.
+
 
 == Introduction
 

--- a/modules/classic_ui/pages/external_storage/external_storage.adoc
+++ b/modules/classic_ui/pages/external_storage/external_storage.adoc
@@ -1,7 +1,10 @@
 = Configuring External Storage
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:external_storage/external_storage.adoc, \
 {latest-server-version}@server:user_manual:external_storage/external_storage.adoc, \
 {previous-server-version}@server:user_manual:external_storage/external_storage.adoc
+endif::[]
 :description: The External Storage application allows you to mount external storage services, such as Google Drive, Dropbox, Amazon S3, SMB/CIFS fileservers, and FTP servers in ownCloud. Your ownCloud server administrator controls which of these are available to you.
 
 {description} Please see

--- a/modules/classic_ui/pages/external_storage/sharepoint_connecting.adoc
+++ b/modules/classic_ui/pages/external_storage/sharepoint_connecting.adoc
@@ -1,8 +1,11 @@
 = Connecting to SharePoint (Enterprise only)
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:external_storage/sharepoint_connecting.adoc, \
 {latest-server-version}@server:user_manual:external_storage/sharepoint_connecting.adoc, \
 {previous-server-version}@server:user_manual:external_storage/sharepoint_connecting.adoc
+endif::[]
 :description: Native SharePoint support has been added to ownCloud Enterprise Subscription as a secondary storage location for SharePoint 2007, 2010 and 2013. To the user, these appear as normal ownCloud mounts, with bi-directional updates in any ownCloud client: desktop, mobile, or Web.
 
 == Introduction

--- a/modules/classic_ui/pages/files/access_webdav.adoc
+++ b/modules/classic_ui/pages/files/access_webdav.adoc
@@ -1,5 +1,13 @@
 = Accessing ownCloud Files Using WebDAV
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
+:page-aliases: next@server:user_manual:files/access_webdav.adoc, \
+{latest-server-version}@server:user_manual:files/access_webdav.adoc, \
+{previous-server-version}@server:user_manual:files/access_webdav.adoc
+endif::[]
+:description: ownCloud fully supports the WebDAV protocol, and you can connect and synchronize with your ownCloud files over WebDAV. In this chapter you will learn how to connect Linux, Mac OS X, Windows and mobile devices to your ownCloud server via WebDAV.
+
 :ocsmount-url: https://apps.apple.com/de/app/ocsmount/id1411490371
 :webdav-navigator-url: http://seanashton.net/webdav/
 :schimera-url: https://play.google.com/store/apps/details?id=com.schimera.webdavnavlite
@@ -9,10 +17,6 @@
 :office-opens-blank-url: https://docs.microsoft.com/en-us/office/troubleshoot/powerpoint/office-opens-blank-from-sharepoint
 :support-1-url: https://support.microsoft.com/kb/2123563
 :support-2-url: https://support.microsoft.com/kb/2668751
-:page-aliases: next@server:user_manual:files/access_webdav.adoc, \
-{latest-server-version}@server:user_manual:files/access_webdav.adoc, \
-{previous-server-version}@server:user_manual:files/access_webdav.adoc
-:description: ownCloud fully supports the WebDAV protocol, and you can connect and synchronize with your ownCloud files over WebDAV. In this chapter you will learn how to connect Linux, Mac OS X, Windows and mobile devices to your ownCloud server via WebDAV.
 
 == Introduction
 

--- a/modules/classic_ui/pages/files/deleted_file_management.adoc
+++ b/modules/classic_ui/pages/files/deleted_file_management.adoc
@@ -1,8 +1,11 @@
 = Managing Deleted Files
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/deleted_file_management.adoc, \
 {latest-server-version}@server:user_manual:files/deleted_file_management.adoc, \
 {previous-server-version}@server:user_manual:files/deleted_file_management.adoc
+endif::[]
 :description: When you delete a file in ownCloud, it is not immediately deleted permanently. Instead, it is moved into the trash bin. It is not permanently deleted until you manually delete it, or when the Deleted Files app deletes it to make room for new files.
 
 == Introduction

--- a/modules/classic_ui/pages/files/desktop_mobile_sync.adoc
+++ b/modules/classic_ui/pages/files/desktop_mobile_sync.adoc
@@ -1,7 +1,10 @@
 = Desktop and Mobile Synchronization
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/desktop_mobile_sync.adoc, \
 {latest-server-version}@server:user_manual:files/desktop_mobile_sync.adoc, \
 {previous-server-version}@server:user_manual:files/desktop_mobile_sync.adoc
+endif::[]
 :description: Syncronizing files with your desktop computer is easiest with the Desktop Synchronisation Client. While it is not mandatory, it eases keeping files in sync a lot.
 
 == Introduction

--- a/modules/classic_ui/pages/files/encrypting_files.adoc
+++ b/modules/classic_ui/pages/files/encrypting_files.adoc
@@ -1,8 +1,11 @@
 = Encrypting Your ownCloud Files
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/encrypting_files.adoc, \
 {latest-server-version}@server:user_manual:files/encrypting_files.adoc, \
 {previous-server-version}@server:user_manual:files/encrypting_files.adoc
+endif::[]
 :description: ownCloud includes an Encryption app, and when it is enabled by your ownCloud administrator, all of your ownCloud data files are automatically encrypted.
 
 == Introduction

--- a/modules/classic_ui/pages/files/federated_cloud_sharing.adoc
+++ b/modules/classic_ui/pages/files/federated_cloud_sharing.adoc
@@ -1,8 +1,11 @@
 = Using Federation Shares
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/federated_cloud_sharing.adoc, \
 {latest-server-version}@server:user_manual:files/federated_cloud_sharing.adoc, \
 {previous-server-version}@server:user_manual:files/federated_cloud_sharing.adoc
+endif::[]
 :description: Federation Sharing allows you to mount file shares from remote ownCloud
 servers, in effect creating your own cloud of ownClouds.
 

--- a/modules/classic_ui/pages/files/files_lifecycle.adoc
+++ b/modules/classic_ui/pages/files/files_lifecycle.adoc
@@ -1,8 +1,11 @@
 = File Lifecycle Management
 :toc: right
 :page-aliases: next@server:user_manual:files/files_lifecycle.adoc, \
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 {latest-server-version}@server:user_manual:files/files_lifecycle.adoc, \
 {previous-server-version}@server:user_manual:files/files_lifecycle.adoc
+endif::[]
 :description: With File Lifecycle Management, ownCloud provides a toolset for administrators to automatically move user files into a dedicated archive a certain time after they were uploaded. 
 
 == Introduction

--- a/modules/classic_ui/pages/files/index.adoc
+++ b/modules/classic_ui/pages/files/index.adoc
@@ -1,6 +1,9 @@
 = Files
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/index.adoc, \
 {latest-server-version}@server:user_manual:files/index.adoc, \
 {previous-server-version}@server:user_manual:files/index.adoc
+endif::[]
 
 This section covers how to work with and user files when using ownCloud.

--- a/modules/classic_ui/pages/files/large_file_upload.adoc
+++ b/modules/classic_ui/pages/files/large_file_upload.adoc
@@ -1,7 +1,10 @@
 = Large File Uploads
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/large_file_upload.adoc, \
 {latest-server-version}@server:user_manual:files/large_file_upload.adoc, \
 {previous-server-version}@server:user_manual:files/large_file_upload.adoc
+endif::[]
 :description: When uploading files through the web client, ownCloud is limited by the server configuration. We recommend that your ownCloud admin updates the server environment to sizes appropriate for users.
 
 {description}

--- a/modules/classic_ui/pages/files/manual_file_locking.adoc
+++ b/modules/classic_ui/pages/files/manual_file_locking.adoc
@@ -1,8 +1,11 @@
 = Manual File Locking
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/manual_file_locking.adoc, \
 {latest-server-version}@server:user_manual:files/manual_file_locking.adoc, \
 {previous-server-version}@server:user_manual:files/manual_file_locking.adoc
+endif::[]
 :description: If enabled by the ownCloud administrator, manual file locking allows users to lock files in shared areas while working on them in order to prevent concurrent changes from other users (check-in/check-out).
 
 == Introduction

--- a/modules/classic_ui/pages/files/public_link_shares.adoc
+++ b/modules/classic_ui/pages/files/public_link_shares.adoc
@@ -1,7 +1,10 @@
 = Public Link Shares
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/public_link_shares.adoc, \
 {latest-server-version}@server:user_manual:files/public_link_shares.adoc, \
 {previous-server-version}@server:user_manual:files/public_link_shares.adoc
+endif::[]
 :description: With ownCloud X (10.0), the ability to create multiple public links per file or folder was introduced.
 This offers a lot of flexibility for creating different 
 

--- a/modules/classic_ui/pages/files/version_control.adoc
+++ b/modules/classic_ui/pages/files/version_control.adoc
@@ -1,9 +1,12 @@
 = Version Control
 :tab-type-text: versions
 :tab-type-link: versions
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/version_control.adoc, \
 {latest-server-version}@server:user_manual:files/version_control.adoc, \
 {previous-server-version}@server:user_manual:files/version_control.adoc
+endif::[]
 :description: ownCloud provides a simple version control system for files. Versioning creates backups of files which are accessible via the Versions tab on the Details sidebar.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/activity.adoc
+++ b/modules/classic_ui/pages/files/webgui/activity.adoc
@@ -2,9 +2,12 @@
 :toc: right
 :tab-type-text: sharing
 :tab-type-link: share
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/webgui/activity.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/activity.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/activity.adoc
+endif::[]
 :description: Clicking the Activity tab in the Details view in the web browser shows all activities for a file. Activities can include when a file was created, renamed, and deleted.
 
 {description}

--- a/modules/classic_ui/pages/files/webgui/comments.adoc
+++ b/modules/classic_ui/pages/files/webgui/comments.adoc
@@ -2,9 +2,12 @@
 :toc: right
 :tab-type-text: comments
 :tab-type-link: comments
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/webgui/comments.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/comments.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/comments.adoc
+endif::[]
 :description: In ownCloud, you can add one or more comments on both files and folders. This section describes how to add, edit, and delete comments.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/details.adoc
+++ b/modules/classic_ui/pages/files/webgui/details.adoc
@@ -2,9 +2,12 @@
 :toc: right
 :tab-type-text: sharing
 :tab-type-link: share
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/webgui/details.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/details.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/details.adoc
+endif::[]
 :description: The Details view shows all information for a file, split up into four sections:
 
 {description}

--- a/modules/classic_ui/pages/files/webgui/navigating.adoc
+++ b/modules/classic_ui/pages/files/webgui/navigating.adoc
@@ -2,9 +2,12 @@
 :toc: right
 :toclevels: 1
 :moz-browser-compatibility-guide-url: https://developer.mozilla.org/en-US/docs/Web/Media/Formats#Browser_compatibility
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/webgui/navigating.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/navigating.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/navigating.adoc
+endif::[]
 :description: Navigating through folders in ownCloud is as simple as clicking on a folder to open it and using the back button on your browser to move to a previous level. This section walks you through how to navigate the ownCloud UI.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/overview.adoc
+++ b/modules/classic_ui/pages/files/webgui/overview.adoc
@@ -1,9 +1,12 @@
 = WebUI Overview
 :toc: right
 :toclevels: 1
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/webgui/overview.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/overview.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/overview.adoc
+endif::[]
 :description: You can access your files with the ownCloud Web interface, as well as: create, preview, edit, delete, share, and re-share files.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/quota.adoc
+++ b/modules/classic_ui/pages/files/webgui/quota.adoc
@@ -1,8 +1,11 @@
 = Storage Quotas
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/webgui/quota.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/quota.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/quota.adoc
+endif::[]
 :description: Your ownCloud admin has the option to set a storage quota on users. Look
 at the top of your Personal page to see what your quota is, and how much
 you have used.

--- a/modules/classic_ui/pages/files/webgui/search.adoc
+++ b/modules/classic_ui/pages/files/webgui/search.adoc
@@ -1,8 +1,11 @@
 = Search & Full Text Search
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/webgui/search.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/search.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/search.adoc
+endif::[]
 :description: ownCloud comes with a regular search function allowing you to find files by their file name or parts of their names. Click on the magnifier icon in the upper right-hand corner of the web interface. In addition, a Full Text Search app can be enabled by your administrator.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/sharing.adoc
+++ b/modules/classic_ui/pages/files/webgui/sharing.adoc
@@ -2,9 +2,12 @@
 :toc: right
 :tab-type-text: sharing
 :tab-type-link: share
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/webgui/sharing.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/sharing.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/sharing.adoc
+endif::[]
 :description: Clicking the share icon on any file or folder opens the Details view on the right, where the Share tab has focus.
 
 == Introduction

--- a/modules/classic_ui/pages/files/webgui/tagging.adoc
+++ b/modules/classic_ui/pages/files/webgui/tagging.adoc
@@ -1,8 +1,11 @@
 = Tagging Files
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:files/webgui/tagging.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/tagging.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/tagging.adoc
+endif::[]
 :description: ownCloud provides via the webinterface the ability to assign one or more tags to files and folders.
 
 == Introduction

--- a/modules/classic_ui/pages/found_a_mistake.adoc
+++ b/modules/classic_ui/pages/found_a_mistake.adoc
@@ -1,8 +1,11 @@
 = Have You Found a Mistake In The Documentation?
 :description: If you have found a mistake in the documentation, no matter how large or small, please let us know.
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:found_a_mistake.adoc, \
 {latest-server-version}@server:user_manual:found_a_mistake.adoc, \
 {previous-server-version}@server:user_manual:found_a_mistake.adoc
+endif::[]
 
 :new-issue-url: https://github.com/owncloud/docs/issues/new
 

--- a/modules/classic_ui/pages/index.adoc
+++ b/modules/classic_ui/pages/index.adoc
@@ -1,8 +1,11 @@
 = Introduction
 :description: ownCloud is an open source file sync and share software for everyone from individuals operating the free ownCloud Server edition, to large enterprises and service providers operating the ownCloud Enterprise Subscription.
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:index.adoc, \
 {latest-server-version}@server:user_manual:index.adoc, \
 {previous-server-version}@server:user_manual:index.adoc
+endif::[]
 
 *Welcome to ownCloud: your self-hosted file sync and share solution.*
 

--- a/modules/classic_ui/pages/integration/index.adoc
+++ b/modules/classic_ui/pages/integration/index.adoc
@@ -1,7 +1,10 @@
 = Integration
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:integration/index.adoc, \
 {latest-server-version}@server:user_manual:integration/index.adoc, \
 {previous-server-version}@server:user_manual:integration/index.adoc
+endif::[]
 
 This section is dedicated to integrating ownCloud with other products, for now only Microsoft Teams, but more to come.
 

--- a/modules/classic_ui/pages/integration/ms-teams.adoc
+++ b/modules/classic_ui/pages/integration/ms-teams.adoc
@@ -1,8 +1,11 @@
 = Integrate ownCloud into Microsoft Teams
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:integration/ms-teams.adoc, \
 {latest-server-version}@server:user_manual:integration/ms-teams.adoc, \
 {previous-server-version}@server:user_manual:integration/ms-teams.adoc
+endif::[]
 :description: You can access your ownCloud via Microsoft Teams if your administrator has created an app available in your organization's app catalog. It is possible that the admin already has enabled the app for the users, in this case you do not need to search for it in your organization's app catalog as it is already pinned.
 
 == Introduction

--- a/modules/classic_ui/pages/online_collaboration.adoc
+++ b/modules/classic_ui/pages/online_collaboration.adoc
@@ -1,13 +1,16 @@
 = Online Collaboration
 :toc: right
 :description: Collabora Online is a powerful LibreOffice based online office that supports all major document, spreadsheet and presentation file formats, and is integrable with ownCloud.
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
+:page-aliases: next@server:user_manual:online_collaboration.adoc, \
+{latest-server-version}@server:user_manual:online_collaboration.adoc, \
+{previous-server-version}@server:user_manual:online_collaboration.adoc
+endif::[]
 
 :collabora-online-url: https://www.collaboraoffice.com/collabora-online/
 :libreoffice-url: https://www.libreoffice.org/
 :secure-view-label: Secure View (with watermarks)
-:page-aliases: next@server:user_manual:online_collaboration.adoc, \
-{latest-server-version}@server:user_manual:online_collaboration.adoc, \
-{previous-server-version}@server:user_manual:online_collaboration.adoc
 
 == Collabora Online
 

--- a/modules/classic_ui/pages/personal_settings/custom_groups.adoc
+++ b/modules/classic_ui/pages/personal_settings/custom_groups.adoc
@@ -1,9 +1,12 @@
 = Custom Groups
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: files/webgui/custom_groups.adoc, \
 next@server:user_manual:files/webgui/custom_groups.adoc, \
 {latest-server-version}@server:user_manual:files/webgui/custom_groups.adoc, \
 {previous-server-version}@server:user_manual:files/webgui/custom_groups.adoc
+endif::[]
 :description: With custom groups, users are able to define their own groups and manage contributing users themselves.
 
 == Introduction

--- a/modules/classic_ui/pages/personal_settings/general.adoc
+++ b/modules/classic_ui/pages/personal_settings/general.adoc
@@ -1,9 +1,12 @@
 = General Settings
 :toc: right
 :toclevels: 2
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:personal_settings/general.adoc, \
 {latest-server-version}@server:user_manual:personal_settings/general.adoc, \
 {previous-server-version}@server:user_manual:personal_settings/general.adoc
+endif::[]
 :description: In general settings, some of the features you will see include the following:
 
 == Introduction

--- a/modules/classic_ui/pages/personal_settings/index.adoc
+++ b/modules/classic_ui/pages/personal_settings/index.adoc
@@ -1,7 +1,10 @@
 = Personal Settings
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:personal_settings/index.adoc, \
 {latest-server-version}@server:user_manual:personal_settings/index.adoc, \
 {previous-server-version}@server:user_manual:personal_settings/index.adoc
+endif::[]
 :description: As a user, you can manage your personal settings. To access them: Click on your username in the top, right-hand corner of the WebUI of your ownCloud instance.
 
 {description} The Personal Settings Menu opens.

--- a/modules/classic_ui/pages/personal_settings/security.adoc
+++ b/modules/classic_ui/pages/personal_settings/security.adoc
@@ -1,14 +1,18 @@
 = Security
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
+:page-aliases: next@server:user_manual:personal_settings/security.adoc, \
+{latest-server-version}@server:user_manual:personal_settings/security.adoc, \
+{previous-server-version}@server:user_manual:personal_settings/security.adoc
+endif::[]
+
 :cors-url: https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
 :gps-ms-auth-url: https://play.google.com/store/apps/details?id=com.azure.authenticator&hl=en&gl=US
 :ios-ms-auth-url: https://apps.apple.com/us/app/microsoft-authenticator/id983156458
 :gps-google-auth-url: https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en&gl=US
 :ios-2fas-url: https://apps.apple.com/app/2fa-authenticator-2fas/id1217793794
 :gps-2fas-url: https://play.google.com/store/apps/details?id=com.twofasapp&hl=en&gl=US
-:page-aliases: next@server:user_manual:personal_settings/security.adoc, \
-{latest-server-version}@server:user_manual:personal_settings/security.adoc, \
-{previous-server-version}@server:user_manual:personal_settings/security.adoc
 
 == Introduction
 

--- a/modules/classic_ui/pages/personal_settings/sharing.adoc
+++ b/modules/classic_ui/pages/personal_settings/sharing.adoc
@@ -1,7 +1,10 @@
 = Sharing
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:personal_settings/sharing.adoc, \
 {latest-server-version}@server:user_manual:personal_settings/sharing.adoc, \
 {previous-server-version}@server:user_manual:personal_settings/sharing.adoc
+endif::[]
 
 == Introduction
 

--- a/modules/classic_ui/pages/personal_settings/storage.adoc
+++ b/modules/classic_ui/pages/personal_settings/storage.adoc
@@ -1,7 +1,10 @@
 = External Storage
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:personal_settings/storage.adoc, \
 {latest-server-version}@server:user_manual:personal_settings/storage.adoc, \
 {previous-server-version}@server:user_manual:personal_settings/storage.adoc
+endif::[]
 :description: If your ownCloud administrator has enabled *External Storage* for users, you will be able to add one or multiple external storages depending on the allowed storage types.
 
 == Introduction

--- a/modules/classic_ui/pages/pim/index.adoc
+++ b/modules/classic_ui/pages/pim/index.adoc
@@ -1,7 +1,10 @@
 = Contacts & Calendar
+:description: The Contacts, Calendar, and Mail apps can be installed from the ownCloud Marketplace in the  menu:Market[Productivity] category and can be installed by clicking btn:[Install] on their respective entries but are not with official support.
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:pim/index.adoc, \
 {latest-server-version}@server:user_manual:pim/index.adoc, \
 {previous-server-version}@server:user_manual:pim/index.adoc
-:description: The Contacts, Calendar, and Mail apps can be installed from the ownCloud Marketplace in the  menu:Market[Productivity] category and can be installed by clicking btn:[Install] on their respective entries but are not with official support.
+endif::[]
 
 {description}

--- a/modules/classic_ui/pages/pim/sync_ios.adoc
+++ b/modules/classic_ui/pages/pim/sync_ios.adoc
@@ -1,8 +1,11 @@
 = iOS - Synchronize iPhone/iPad
 :toc: right
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:pim/sync_ios.adoc, \
 {latest-server-version}@server:user_manual:pim/sync_ios.adoc, \
 {previous-server-version}@server:user_manual:pim/sync_ios.adoc
+endif::[]
 
 == Calendar
 

--- a/modules/classic_ui/pages/pim/sync_kde.adoc
+++ b/modules/classic_ui/pages/pim/sync_kde.adoc
@@ -1,7 +1,10 @@
 = Synchronizing with KDE SC
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:pim/sync_kde.adoc, \
 {latest-server-version}@server:user_manual:pim/sync_kde.adoc, \
 {previous-server-version}@server:user_manual:pim/sync_kde.adoc
+endif::[]
 
 image:kdes1.png[image]
 

--- a/modules/classic_ui/pages/pim/sync_osx.adoc
+++ b/modules/classic_ui/pages/pim/sync_osx.adoc
@@ -1,7 +1,10 @@
 = Synchronizing with OS X
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:pim/sync_osx.adoc, \
 {latest-server-version}@server:user_manual:pim/sync_osx.adoc, \
 {previous-server-version}@server:user_manual:pim/sync_osx.adoc
+endif::[]
 
 To use ownCloud with iCal you will need to use the following URL:
 

--- a/modules/classic_ui/pages/pim/sync_thunderbird.adoc
+++ b/modules/classic_ui/pages/pim/sync_thunderbird.adoc
@@ -1,8 +1,10 @@
 = Thunderbird - Synchronize Addressbook
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:pim/sync_thunderbird.adoc, \
 {latest-server-version}@server:user_manual:pim/sync_thunderbird.adoc, \
 {previous-server-version}@server:user_manual:pim/sync_thunderbird.adoc
-
+endif::[]
 
 As someone who is new to ownCloud, new to SoGo Connector, and new to
 Thunderbird Addressbook, here is what you need in excruciating pithy

--- a/modules/classic_ui/pages/session_management.adoc
+++ b/modules/classic_ui/pages/session_management.adoc
@@ -1,9 +1,12 @@
 = Session Management
 :toc: right
 :description: The personal settings page allows you to have an overview of the connected browsers and clients.
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:session_management.adoc, \
 {latest-server-version}@server:user_manual:session_management.adoc, \
 {previous-server-version}@server:user_manual:session_management.adoc
+endif::[]
 
 == Introduction
 

--- a/modules/classic_ui/pages/troubleshooting.adoc
+++ b/modules/classic_ui/pages/troubleshooting.adoc
@@ -1,9 +1,12 @@
 = Troubleshooting
 :toc: right
 :description: Listed here are the most common errors you may encounter while attempting to upload files, along with what they mean and possible workarounds.
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:troubleshooting.adoc, \
 {latest-server-version}@server:user_manual:troubleshooting.adoc, \
 {previous-server-version}@server:user_manual:troubleshooting.adoc
+endif::[]
 
 == Introduction
 

--- a/modules/classic_ui/pages/webinterface.adoc
+++ b/modules/classic_ui/pages/webinterface.adoc
@@ -1,8 +1,11 @@
 = The Web Interface
 :description: You can connect to your ownCloud server using any Web browser; just point it to your ownCloud server and enter your username and password. Supported Web browsers are:
+// for local build only omitting 'next@server' as it creates a build error 
+ifeval::["{latest-server-version}" != "next"]
 :page-aliases: next@server:user_manual:webinterface.adoc, \
 {latest-server-version}@server:user_manual:webinterface.adoc, \
 {previous-server-version}@server:user_manual:webinterface.adoc
+endif::[]
 
 == Introduction
 


### PR DESCRIPTION
The page aliases for the classic_ui need a fix to avoid build errors when when we will update the site.yml for the antora 3 changes. See #158