### PR TITLE
Convert an xref to a link

### DIFF
--- a/modules/owncloud_web/pages/index.adoc
+++ b/modules/owncloud_web/pages/index.adoc
@@ -18,4 +18,4 @@ For readers already familiar with ownCloud 10 and its standard web interface, th
 
 == Security Aspects
 
-The development of ownCloud Web is closely aligned to the development of Infinite Scale. Read the Infinite Scale xref:{latest-ocis-version}@ocis:ROOT:security/security.adoc[Security Aspects] document for more details.
+The development of ownCloud Web is closely aligned to the development of Infinite Scale. Read the Infinite Scale https://doc.owncloud.com/ocis/next/deployment/security/security.html[Security Aspects] document for more details.


### PR DESCRIPTION
Necessary for #158 (Antora 3.1 Upgrade)

By converting this single and only xref to the ocis docs to a html link, we do not need to add in docs-server a content source for ocis when that repo is going to be upgraded to Antora 3. We then can also remove the ocis content source here speeding up build time. The upcoming Antora Atlas could handle this, but this is future.

