### PR TITLE
docs: normalize legacy server product name to "ownCloud Classic"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Since April 2026, this repository requires [Commit Signing](https://docs.github.
 
 ## Building the Web User Interface Docs
 
-The ownCloud Web User Interface Guides are not built independently. Instead, it is built together with the [main documentation](https://github.com/owncloud/docs/). However, you can build a local copy of the ownCloud Server documentation to preview changes you are making.
+The ownCloud Web User Interface Guides are not built independently. Instead, it is built together with the [main documentation](https://github.com/owncloud/docs/). However, you can build a local copy of the ownCloud Classic documentation to preview changes you are making.
 
 Whenever a Pull Request of this repo gets merged, it automatically triggers a full docs build.
 
@@ -34,7 +34,7 @@ See the [following section](https://github.com/owncloud/docs#target-branch-and-b
 
 ## Branching Workflow
 
-Please refer to the [Branching Workflow for ownCloud Server](https://github.com/owncloud/docs-webui/blob/master/docs/the-branching-workflow.md) for more information.
+Please refer to the [Branching Workflow for ownCloud Classic](https://github.com/owncloud/docs-webui/blob/master/docs/the-branching-workflow.md) for more information.
 
 ## Create a New Version Branch for Web User Interfaces
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -2,7 +2,7 @@
 
 Welcome to the ownCloud Web User Interfaces guide. The guide covers access to the ownCloud instance via browser.
 
-Note that the xref:{latest-server-version}@server:classic_ui:index.adoc[ownCloud Server UI] guide is only available for ownCloud Server.
+Note that the xref:{latest-server-version}@server:classic_ui:index.adoc[ownCloud Classic UI] guide is only available for ownCloud Classic.
 
 Note that the client user guides for Desktop, Android or iOS have their own documentation.
 
@@ -10,7 +10,7 @@ To get a first impression about the two web interfaces, see the screenshots belo
 
 [width="100%",cols="~,~",options="header"]
 |===
-^| ownCloud Server UI
+^| ownCloud Classic UI
 ^| ownCloud Web
 
 ^| image:{latest-server-version}@server:classic_ui:files_page.png[width=320]

--- a/modules/owncloud_web/pages/index.adoc
+++ b/modules/owncloud_web/pages/index.adoc
@@ -10,7 +10,7 @@ If you are still running ownCloud Classic, consider installing the {oc-marketpla
 
 == Changes
 
-For readers already familiar with ownCloud Classic 10 and its standard web interface, the big differences in the new ownCloud Web on Infinite Scale are:
+For readers already familiar with ownCloud Classic and its standard web interface, the big differences in the new ownCloud Web on Infinite Scale are:
 
 * Spaces: Spaces are special folders for teams. They are organized by the team members themselves so that admins don't need to manage them. Even if members leave, the files stay in place so your team can keep on working.
 * Simplified links: Just select if only invited people or everyone can access a link. In consequence, we no longer distinguish between private and public links.

--- a/modules/owncloud_web/pages/index.adoc
+++ b/modules/owncloud_web/pages/index.adoc
@@ -6,11 +6,11 @@
 
 {description}
 
-If you are still running ownCloud Server, consider installing the {oc-marketplace-url}/apps/web[Web] app, which provides the new look and feel plus some additional features, but not everything ownCloud Web has to offer when used with Infinite Scale. For a quick introduction about what's new or different, check out the section xref:web_with_oc_server.adoc[ownCloud Web on ownCloud Server].
+If you are still running ownCloud Classic, consider installing the {oc-marketplace-url}/apps/web[Web] app, which provides the new look and feel plus some additional features, but not everything ownCloud Web has to offer when used with Infinite Scale. For a quick introduction about what's new or different, check out the section xref:web_with_oc_server.adoc[ownCloud Web on ownCloud Classic].
 
 == Changes
 
-For readers already familiar with ownCloud 10 and its standard web interface, the big differences in the new ownCloud Web on Infinite Scale are:
+For readers already familiar with ownCloud Classic 10 and its standard web interface, the big differences in the new ownCloud Web on Infinite Scale are:
 
 * Spaces: Spaces are special folders for teams. They are organized by the team members themselves so that admins don't need to manage them. Even if members leave, the files stay in place so your team can keep on working.
 * Simplified links: Just select if only invited people or everyone can access a link. In consequence, we no longer distinguish between private and public links.

--- a/modules/owncloud_web/pages/web_for_users.adoc
+++ b/modules/owncloud_web/pages/web_for_users.adoc
@@ -12,7 +12,7 @@ If this file gets relocated or renamed, a page alias must be added to make it av
 
 {description}
 
-If you have been using ownCloud before but with the ownCloud Server user interface, you may want to check out section xref:web_with_oc_server.adoc[ownCloud Web with ownCloud Server] to get an overview of the main differences.
+If you have been using ownCloud before but with the ownCloud Classic user interface, you may want to check out section xref:web_with_oc_server.adoc[ownCloud Web with ownCloud Classic] to get an overview of the main differences.
 
 The following description assumes you're new to ownCloud.
 

--- a/modules/owncloud_web/pages/web_with_oc_server.adoc
+++ b/modules/owncloud_web/pages/web_with_oc_server.adoc
@@ -62,7 +62,7 @@ If you prefer to use {oc-marketplace-url}/oauth2[OAuth2], log in as admin, go to
 
 === Server Configuration
 
-A few configuration steps are necessary on the ownCloud Classic 10 server:
+A few configuration steps are necessary on the ownCloud Classic server:
 
 . Set the ownCloud Web address so it gets displayed in the app switcher by adding the following line to the `config/config.php` file:
 +
@@ -89,7 +89,7 @@ NOTE: While it is possible to make ownCloud Web the default interface, the decis
 
 include::partial$/web-configuration.adoc[]
 
-=== Integrate Traditional ownCloud Classic 10 Features in ownCloud Web
+=== Integrate Traditional ownCloud Classic Features in ownCloud Web
 
 ownCloud features that are not deeply integrated in the regular web interface can be added to the app switcher and to the user menu.
 
@@ -131,7 +131,7 @@ TIP: This will add a link to the specified URL in the user menu. The link will o
 
 === ONLYOFFICE Integration
 
-For ONLYOFFICE there is a {onlyoffice-owncloud-web-url}[native integration] available for ownCloud Web when it is used with an ownCloud Classic. It fully integrates the ONLYOFFICE document editors and allows users to create and open documents directly in ownCloud Web.
+For ONLYOFFICE there is a {onlyoffice-owncloud-web-url}[native integration] available for ownCloud Web when it is used with an ownCloud Classic server. It fully integrates the ONLYOFFICE document editors and allows users to create and open documents directly in ownCloud Web.
 
 To use ONLYOFFICE in ownCloud Web, you need:
 
@@ -155,7 +155,7 @@ NOTE: Adjust the URL in the example according to your setup.
 
 === Collabora Online Integration
 
-There is a native Collabora Online integration available for ownCloud Web when it is used with an ownCloud Classic. It fully integrates the Collabora Online document editors and allows users to create and open documents directly in ownCloud Web.
+There is a native Collabora Online integration available for ownCloud Web when it is used with an ownCloud Classic server. It fully integrates the Collabora Online document editors and allows users to create and open documents directly in ownCloud Web.
 
 Requirements:
 

--- a/modules/owncloud_web/pages/web_with_oc_server.adoc
+++ b/modules/owncloud_web/pages/web_with_oc_server.adoc
@@ -1,6 +1,6 @@
-= ownCloud Web on ownCloud Server
+= ownCloud Web on ownCloud Classic
 :toc: right
-:description: ownCloud web is available for ownCloud Server as an app. To ease the transition from ownCloud Server to Infinite Scale, we recommend deploying the new user interface.
+:description: ownCloud web is available for ownCloud Classic as an app. To ease the transition from ownCloud Classic to Infinite Scale, we recommend deploying the new user interface.
 
 :onlyoffice-owncloud-web-url: https://github.com/ONLYOFFICE/onlyoffice-owncloud-web
 
@@ -62,7 +62,7 @@ If you prefer to use {oc-marketplace-url}/oauth2[OAuth2], log in as admin, go to
 
 === Server Configuration
 
-A few configuration steps are necessary on the ownCloud 10 server:
+A few configuration steps are necessary on the ownCloud Classic 10 server:
 
 . Set the ownCloud Web address so it gets displayed in the app switcher by adding the following line to the `config/config.php` file:
 +
@@ -89,7 +89,7 @@ NOTE: While it is possible to make ownCloud Web the default interface, the decis
 
 include::partial$/web-configuration.adoc[]
 
-=== Integrate Traditional ownCloud 10 Features in ownCloud Web
+=== Integrate Traditional ownCloud Classic 10 Features in ownCloud Web
 
 ownCloud features that are not deeply integrated in the regular web interface can be added to the app switcher and to the user menu.
 
@@ -131,11 +131,11 @@ TIP: This will add a link to the specified URL in the user menu. The link will o
 
 === ONLYOFFICE Integration
 
-For ONLYOFFICE there is a {onlyoffice-owncloud-web-url}[native integration] available for ownCloud Web when it is used with an ownCloud Server. It fully integrates the ONLYOFFICE document editors and allows users to create and open documents directly in ownCloud Web.
+For ONLYOFFICE there is a {onlyoffice-owncloud-web-url}[native integration] available for ownCloud Web when it is used with an ownCloud Classic. It fully integrates the ONLYOFFICE document editors and allows users to create and open documents directly in ownCloud Web.
 
 To use ONLYOFFICE in ownCloud Web, you need:
 
-* ownCloud Server >= 10.8
+* ownCloud Classic >= 10.8
 * ownCloud Web >= 4.0.0
 * {oc-marketplace-url}/onlyoffice[ONLYOFFICE connector] >= 7.1.1
 
@@ -155,7 +155,7 @@ NOTE: Adjust the URL in the example according to your setup.
 
 === Collabora Online Integration
 
-There is a native Collabora Online integration available for ownCloud Web when it is used with an ownCloud Server. It fully integrates the Collabora Online document editors and allows users to create and open documents directly in ownCloud Web.
+There is a native Collabora Online integration available for ownCloud Web when it is used with an ownCloud Classic. It fully integrates the Collabora Online document editors and allows users to create and open documents directly in ownCloud Web.
 
 Requirements:
 

--- a/modules/owncloud_web/partials/nav.adoc
+++ b/modules/owncloud_web/partials/nav.adoc
@@ -2,6 +2,6 @@
 * ownCloud Web
 ** xref:owncloud_web:index.adoc[Introduction]
 ** xref:owncloud_web:requirements.adoc[Requirements]
-** xref:owncloud_web:web_with_oc_server.adoc[ownCloud Web on ownCloud Server]
+** xref:owncloud_web:web_with_oc_server.adoc[ownCloud Web on ownCloud Classic]
 ** xref:owncloud_web:web_for_users.adoc[ownCloud Web for Users]
 ** xref:owncloud_web:web_for_admins.adoc[ownCloud Web for Admins]

--- a/modules/owncloud_web/partials/web-configuration.adoc
+++ b/modules/owncloud_web/partials/web-configuration.adoc
@@ -64,7 +64,7 @@ TIP: If any issues arise when trying to access the new design, a good start for 
 | Description
 
 | server
-| ownCloud Server address
+| ownCloud Classic address
 
 | theme
 | theme to be used in ownCloud Web pointing to a json file in the themes folder


### PR DESCRIPTION
## What

Normalizes the legacy ownCloud server product to its canonical name **ownCloud Classic** across all user-facing documentation in this repo. Version (10/11) is retained only as trailing information where relevant (e.g. "ownCloud Classic 10").

Normalized: `ownCloud Server`, `owncloud Server`, `ownCloud Classic Server`, and bare `ownCloud 10/11`.

## Why

Part of owncloud/docs#5111 — a coordinated, docs-only rebranding so the legacy product is consistently named **ownCloud Classic** across the `owncloud` / `owncloud-docker` orgs. Reference implementation: owncloud/docs-main#187.

## Out of scope (intentionally untouched)

- `xref:`/`include::` targets, module slugs (`classic_ui`, `oc10-app`), URLs, attribute names (e.g. `oc10-api-url`), image paths, anchors
- The new product names: **ownCloud Infinite Scale** / **oCIS**

## Verification

- All target variants normalized; only prose / headings / link display text changed.
- Every `xref`/`include`/URL **target** byte-for-byte identical before/after.
- `oCIS` / `Infinite Scale` occurrence count unchanged.
- No internal xref depends on any heading whose auto-generated anchor changes.

## Reviewer checklist

- [ ] No xref targets / module slugs / URLs altered
- [ ] oCIS / Infinite Scale untouched
- [ ] Version shown only as additional info ("ownCloud Classic 10")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
